### PR TITLE
Stop trusting quality reports written before the verification gate

### DIFF
--- a/app/models/company_proposal.rb
+++ b/app/models/company_proposal.rb
@@ -98,8 +98,20 @@ class CompanyProposal < ActiveRecord::Base
     CompanyProposalQualityService.call(self)
   end
 
+  # The stored report from the last enrichment, used by list views to avoid recomputing
+  # for every row. Reports written before the verification gate existed are treated as
+  # absent rather than trusted: they would tell a reviewer a record is ready while the
+  # detail view blocks it. Ignoring them makes the lists self-heal as records are
+  # re-enriched, with no backfill needed.
+  QUALITY_REPORT_REQUIRED_KEY = "verification_state".freeze
+
   def cached_quality_report
-    agent_details.is_a?(Hash) ? agent_details["quality"] : nil
+    return nil unless agent_details.is_a?(Hash)
+
+    report = agent_details["quality"]
+    return nil unless report.is_a?(Hash) && report[QUALITY_REPORT_REQUIRED_KEY].present?
+
+    report
   end
 
   def publish_ready?

--- a/test/services/proposal_evidence_gate_test.rb
+++ b/test/services/proposal_evidence_gate_test.rb
@@ -91,6 +91,25 @@ class ProposalEvidenceGateTest < ActiveSupport::TestCase
     assert(report["blockers"].any? { |b| b.include?("could not be retrieved") && b.include?("linkedin_requires_sign_in") })
   end
 
+  # Lists read a cached report so they do not recompute per row. A report written before
+  # the verification gate existed would claim a record is ready while the detail view
+  # blocks it, so it must not be trusted.
+  test "a cached report predating the verification gate is ignored rather than trusted" do
+    proposal = proposal_with(enriched: false)
+    proposal.update!(agent_details: proposal.agent_details.merge("quality" => { "publish_ready" => true, "score" => 100, "blockers" => [] }))
+
+    assert_nil proposal.cached_quality_report
+    refute CompanyProposalQualityService.call(proposal)["publish_ready"]
+  end
+
+  test "a current cached report is still reused" do
+    proposal = proposal_with(agent_details: fetched_page)
+    fresh = CompanyProposalQualityService.call(proposal)
+    proposal.update!(agent_details: proposal.agent_details.merge("quality" => fresh))
+
+    assert_equal fresh, proposal.reload.cached_quality_report
+  end
+
   test "completeness and verification are reported as separate facts" do
     report = CompanyProposalQualityService.call(proposal_with(enriched: false))
 


### PR DESCRIPTION
Follow-up to #85, found while verifying it on production.

The review queue reads a cached quality report per row instead of recomputing, and reports stored by the previous enrichment run predate `verification_state`. That reproduced exactly the contradiction this work exists to remove:

- `list_review_queue` reported proposal **4044** as `publish_ready: true`
- its own detail view blocked it: *"Proposal #4043 covers the same company"*

A stored report missing `verification_state` is now treated as absent, so lists recompute and the two views agree. This self-heals as records are re-enriched — no backfill migration needed.

`bin/rails test` — **604 runs, 2788 assertions, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)