### PR TITLE
Bring review findings onto the company draft; make the Company tab a work queue

### DIFF
--- a/app/controllers/admin/agent_reviews_controller.rb
+++ b/app/controllers/admin/agent_reviews_controller.rb
@@ -1,23 +1,10 @@
 module Admin
   class AgentReviewsController < BaseController
-    # Bookkeeping fields. Applying them never changes public text, so they are
-    # always offered when the packet proposes them.
-    METADATA_APPLY_FIELDS = %w[
-      quality_status
-      verification_verdict
-      quality_score
-      canonical_domain
-      fingerprint
-    ].freeze
+    # The apply rules and the packet shape live in AgentReviewPacket, so the company
+    # draft can render and act on the same findings without this controller.
+    delegate :metadata_apply_fields, to: :class
 
-    # Public-text fields. A review packet may only write these through
-    # applicable_description, which fails closed unless a critic verdict
-    # authorises a specific string. Keyed by company attribute, not by the
-    # packet's own key names (the packet calls the description
-    # "proposed_description").
-    CONTENT_APPLY_FIELDS = %w[description].freeze
-
-    APPLY_FIELDS = (METADATA_APPLY_FIELDS + CONTENT_APPLY_FIELDS).freeze
+    def self.metadata_apply_fields = AgentReviewPacket::METADATA_APPLY_FIELDS
 
     def show
       load_review
@@ -25,13 +12,13 @@ module Admin
 
     def apply
       load_review
-      return redirect_to custom_admin_agent_review_path(@pipeline_run), alert: "This review is not linked to a company." unless @company
+      return redirect_back_to_review(alert: "This review is not linked to a company.") unless @company
 
-      selected_fields = Array(params[:fields]) & @applicable_corrections.keys
-      return redirect_to custom_admin_agent_review_path(@pipeline_run), alert: apply_nothing_selected_alert if selected_fields.empty?
+      selected_fields = Array(params[:fields]) & @packet.applicable_corrections.keys
+      return redirect_back_to_review(alert: apply_nothing_selected_alert) if selected_fields.empty?
 
       applied_changes = selected_fields.each_with_object({}) do |field, changes|
-        value = cast_proposed_value(field, @applicable_corrections[field])
+        value = cast_proposed_value(field, @packet.applicable_corrections[field])
         @company.public_send("#{field}=", value)
         changes[field] = value
       end
@@ -39,115 +26,48 @@ module Admin
       @company.save!
       record_decision!("applied", applied_changes: applied_changes, selected_fields: selected_fields)
 
-      redirect_to custom_admin_agent_review_path(@pipeline_run), notice: "Applied #{applied_changes.keys.map(&:humanize).map(&:downcase).to_sentence} to #{@company.name}."
+      redirect_back_to_review(notice: "Applied #{applied_changes.keys.map(&:humanize).map(&:downcase).to_sentence} to #{@company.name}.")
     rescue ActiveRecord::RecordInvalid => e
-      redirect_to custom_admin_agent_review_path(@pipeline_run), alert: "Could not apply: #{e.record.errors.full_messages.to_sentence}."
+      redirect_back_to_review(alert: "Could not apply: #{e.record.errors.full_messages.to_sentence}.")
     end
 
     def reject
       load_review
       record_decision!("rejected")
 
-      redirect_to custom_admin_agent_review_path(@pipeline_run), notice: "Agent review rejected without changing company data."
+      redirect_back_to_review(notice: "Agent review rejected without changing company data.")
     end
 
     def follow_up
       load_review
       record_decision!("needs_follow_up")
 
-      redirect_to custom_admin_agent_review_path(@pipeline_run), notice: "Agent review marked for follow-up."
+      redirect_back_to_review(notice: "Agent review marked for follow-up.")
     end
 
     private
 
+    # Acting on findings shown inside a company draft returns to that draft, so the
+    # reviewer never loses the record they were working on.
+    def redirect_back_to_review(**flash_args)
+      if params[:return_to] == "company" && @company
+        redirect_to custom_admin_company_review_path(@company.id, anchor: "agent-review"), **flash_args
+      else
+        redirect_to custom_admin_agent_review_path(@pipeline_run), **flash_args
+      end
+    end
+
     def load_review
       @pipeline_run = PipelineRun.find(params[:id])
-      @details = @pipeline_run.details || {}
-      @company = Company.find_by(id: @details["company_id"])
-      @evidence = Array(@details["evidence"])
-      @tool_results = @details["tool_results"] || {}
-      @proposed_corrections = @details["proposed_corrections"] || @details["proposed_changes"] || {}
-      @description_draft = @details["description_draft"] || {}
-      @description_critic = @details["description_critic"] || {}
-      @review_coordinator = @details["review_coordinator"] || {}
-      @duplicate_review = @details["duplicate_review"] || {}
-      @risks = Array(@details["risks"])
-      load_applicable_corrections
-    end
-
-    # Split the packet's proposed corrections into what an admin can apply here
-    # (keyed by company attribute) and what stays informational. The description
-    # is resolved separately because which string is authorised depends on the
-    # critic verdict, and because a blocked description must explain itself
-    # rather than silently vanish from the form.
-    def load_applicable_corrections
-      @applicable_corrections = @proposed_corrections.slice(*METADATA_APPLY_FIELDS)
-      @description_apply_source = nil
-      @description_apply_block = nil
-
-      candidate = applicable_description
-      if candidate
-        @applicable_corrections["description"] = candidate[:value]
-        @description_apply_source = candidate[:source]
-      end
-
-      @review_only_proposed_corrections = @proposed_corrections.except(*METADATA_APPLY_FIELDS, "proposed_description")
-      @review_only_proposed_corrections["proposed_description"] = @proposed_corrections["proposed_description"] if @proposed_corrections.key?("proposed_description") && candidate.nil?
-    end
-
-    # The description string this packet authorises an admin to publish, or nil
-    # with @description_apply_block set to the reason. Two gates, both required:
-    #
-    #   1. The stored critic verdict must name a specific string — the draft when
-    #      the critic passed it, the critic's own narrower rewrite when it asked
-    #      for a revision. A missing or rejecting verdict authorises nothing.
-    #   2. That exact string must then clear the same deterministic description
-    #      gate the publish path enforces, computed live. A stored verdict alone
-    #      is never sufficient: the packet may predate later prompt or gate
-    #      changes, and the text is about to become public.
-    def applicable_description
-      candidate = critic_authorised_description
-      return nil if candidate.nil?
-
-      verdict = CompanyProposalEnrichmentService.description_critic_for(candidate[:value])
-      return candidate if verdict["verdict"] == "pass"
-
-      issues = Array(verdict["issues"]).map(&:to_s).map(&:downcase).to_sentence.presence
-      @description_apply_block = if issues
-        "The #{candidate[:source]} does not clear the publication gate (#{issues}). Edit the company description directly instead."
-      else
-        "The #{candidate[:source]} does not clear the publication gate. Edit the company description directly instead."
-      end
-      nil
-    end
-
-    def critic_authorised_description
-      proposed = @proposed_corrections["proposed_description"].to_s.strip
-      suggested = @description_critic["suggested_revision"].to_s.strip
-      verdict = @description_critic["verdict"].to_s
-
-      case verdict
-      when "pass"
-        return { value: proposed, source: "critic-approved draft" } if proposed.present?
-
-        @description_apply_block = "The critic passed this record but no proposed description was recorded."
-      when "revise"
-        return { value: suggested, source: "critic's suggested revision" } if suggested.present?
-
-        @description_apply_block = "The critic asked for a revision but did not supply replacement text. Revise the description by hand."
-      when ""
-        @description_apply_block = "No description critic verdict is recorded on this review, so no description can be applied. Re-run the review first." if proposed.present?
-      else
-        @description_apply_block = "The critic returned #{verdict}, so its draft cannot be published. Revise the description by hand."
-      end
-
-      nil
+      @packet = AgentReviewPacket.new(@pipeline_run)
+      @details = @packet.details
+      @company = @packet.company
     end
 
     def apply_nothing_selected_alert
-      return "Select at least one correction to apply." if @applicable_corrections.any?
+      return "Select at least one correction to apply." if @packet.applicable_corrections.any?
 
-      @description_apply_block.presence || "This review has no corrections that can be applied here."
+      @packet.description_apply_block.presence || "This review has no corrections that can be applied here."
     end
 
     def cast_proposed_value(field, value)
@@ -166,9 +86,9 @@ module Admin
         "selected_fields" => selected_fields,
         "applied_changes" => applied_changes
       }
-      # Provenance for the one change that alters public text: record which
-      # string the admin published and why it was authorised.
-      details["admin_decision"]["description_source"] = @description_apply_source if applied_changes.key?("description") && @description_apply_source.present?
+      # Provenance for the one change that alters public text: record which string the
+      # admin published and why it was authorised.
+      details["admin_decision"]["description_source"] = @packet.description_apply_source if applied_changes.key?("description") && @packet.description_apply_source.present?
 
       @pipeline_run.update!(details: details)
     end

--- a/app/controllers/admin/company_management_controller.rb
+++ b/app/controllers/admin/company_management_controller.rb
@@ -24,7 +24,7 @@ module Admin
       @categories = Category.order(:name)
       @business_models = BusinessModel.canonical.order(:name)
       @target_clients = TargetClient.canonical.order(:name)
-      @review_state_options = Company::REVIEW_STATE_FILTER_OPTIONS
+      @review_state_options = Company::REVIEW_STATE_FILTER_OPTIONS.merge("all" => "All records")
       @review_signal_options = REVIEW_SIGNALS
       @updated_since_options = UPDATED_SINCE_OPTIONS
       metrics = AdminDashboardMetrics.load
@@ -33,6 +33,34 @@ module Admin
       @company_summary_counts = metrics[:company_summary_counts]
       @active_filter_count = active_filter_count
       @companies = filtered_companies.page(params[:page]).per(25)
+    end
+
+    # Item 5: run the same agent review across a handful of drafts at once. Capped,
+    # queued one job per company so a failure is contained, and it never approves,
+    # publishes or rejects anything — it only produces findings for a human to read.
+    BATCH_REVIEW_LIMIT = 10
+
+    def batch_agent_review
+      ids = Array(params[:company_ids]).map(&:to_s).reject(&:blank?).uniq
+      return redirect_back(fallback_location: custom_admin_companies_path, alert: "Select at least one company to review.") if ids.empty?
+      if ids.size > BATCH_REVIEW_LIMIT
+        return redirect_back(fallback_location: custom_admin_companies_path,
+                             alert: "Select at most #{BATCH_REVIEW_LIMIT} companies per batch — you selected #{ids.size}.")
+      end
+
+      companies = Company.where(id: ids)
+      # Skip anything already queued or mid-review, so double-submitting a selection
+      # cannot start the same work twice.
+      in_flight = PipelineRun.where(run_type: "company_agent_review", status: %w[pending running])
+                             .where("details->>'company_id' IN (?)", companies.map { |c| c.id.to_s })
+                             .filter_map { |run| run.details["company_id"].to_i }.to_set
+
+      queued, skipped = companies.partition { |company| !in_flight.include?(company.id) }
+      queued.each { |company| CompanyAgentReviewJob.perform_later(company.id, current_admin_user.email) }
+
+      notice = "Queued agent reviews for #{queued.size} #{'company'.pluralize(queued.size)}. Each runs on its own — open a record to read its findings."
+      notice += " #{skipped.size} already had a review in progress and #{skipped.size == 1 ? 'was' : 'were'} skipped." if skipped.any?
+      redirect_back(fallback_location: custom_admin_companies_path, notice: notice)
     end
 
     def new
@@ -133,10 +161,20 @@ module Admin
       scope = scope.where(category_id: @filters[:category_id]) if @filters[:category_id].present?
       scope = scope.where(business_model_id: @filters[:business_model_id]) if @filters[:business_model_id].present?
       scope = scope.where(target_client_id: @filters[:target_client_id]) if @filters[:target_client_id].present?
-      scope = scope.with_review_state(@filters[:review_state]) if @filters[:review_state].present?
+      scope = apply_review_state(scope)
       scope = apply_review_signal(scope)
       scope = scope.where(updated_at: @filters[:updated_since].to_i.days.ago..) if @filters[:updated_since].in?(UPDATED_SINCE_OPTIONS.keys)
       scope
+    end
+
+    # No explicit choice means the working queue: records still needing a decision
+    # before publication. "all" is the escape hatch for browsing the whole index.
+    def apply_review_state(scope)
+      case @filters[:review_state].presence
+      when nil then scope.needs_publishing_review
+      when "all" then scope
+      else scope.with_review_state(@filters[:review_state])
+      end
     end
 
     def apply_review_signal(scope)

--- a/app/controllers/admin/company_reviews_controller.rb
+++ b/app/controllers/admin/company_reviews_controller.rb
@@ -5,13 +5,16 @@ module Admin
       @duplicate_domain_companies = duplicate_domain_companies
       @duplicate_name_companies = duplicate_name_companies
       @company_pipeline_runs = PipelineRun.for_company(@company).recent.limit(10)
+      @agent_review = AgentReviewPacket.latest_agent_review_for(@company)
+      @duplicate_review = AgentReviewPacket.latest_duplicate_review_for(@company)
     end
 
     def create_agent_review
       company = Company.find(params[:id])
-      run = CompanyAgentReviewService.call(company: company, reviewer: current_admin_user.email, notes: "Triggered from custom company review page")
+      CompanyAgentReviewService.call(company: company, reviewer: current_admin_user.email, notes: "Triggered from custom company review page")
 
-      redirect_to custom_admin_agent_review_path(run), notice: "Agent review created for #{company.name}."
+      redirect_to custom_admin_company_review_path(company.id, anchor: "agent-review"),
+                  notice: "Agent review complete for #{company.name}. The findings are below."
     end
 
     def create_next_description_review
@@ -25,9 +28,10 @@ module Admin
 
     def create_duplicate_review
       company = Company.find(params[:id])
-      run = DuplicateDomainReviewService.call(company: company, reviewer: current_admin_user.email, notes: "Triggered from custom company review page")
+      DuplicateDomainReviewService.call(company: company, reviewer: current_admin_user.email, notes: "Triggered from custom company review page")
 
-      redirect_to custom_admin_agent_review_path(run), notice: "Duplicate-domain review created for #{company.name}."
+      redirect_to custom_admin_company_review_path(company.id, anchor: "duplicate-review"),
+                  notice: "Duplicate review complete for #{company.name}. The findings are below."
     end
 
     def create_next_duplicate_domain_review
@@ -55,6 +59,11 @@ module Admin
       if decision == "return_to_contributor"
         return redirect_to custom_admin_companies_path(review_state: "awaiting_contributor"),
                            notice: "#{company.name} was returned to its contributor and is no longer in the review queue."
+      end
+
+      if decision.in?(%w[verified reject])
+        return redirect_to custom_admin_companies_path,
+                           notice: "#{mark_review_notice(decision, company.name)} It has left the review queue."
       end
 
       redirect_to custom_admin_company_review_path(company.id), notice: mark_review_notice(decision, company.name)

--- a/app/jobs/company_agent_review_job.rb
+++ b/app/jobs/company_agent_review_job.rb
@@ -1,0 +1,27 @@
+class CompanyAgentReviewJob < ApplicationJob
+  queue_as :default
+
+  # Runs one company's agent review off the request thread. A batch of these is how the
+  # Company tab offers "review these five" without holding a web request open for five
+  # sequential LLM passes, and a failure on one company leaves the rest untouched.
+  def perform(company_id, reviewer_email = nil)
+    company = Company.find_by(id: company_id)
+    return unless company
+
+    CompanyAgentReviewService.call(
+      company: company,
+      reviewer: reviewer_email,
+      notes: "Queued from a Company tab batch review"
+    )
+  rescue StandardError => e
+    Rails.logger.debug("[CompanyAgentReviewJob] review failed for company #{company_id}: #{e.class}: #{e.message}")
+    PipelineRun.create!(
+      name: "Agent company review failed: #{company&.name || company_id}",
+      run_type: "company_agent_review",
+      status: "failed",
+      agent_name: "CompanyAgentReviewJob",
+      records_processed: 0,
+      details: { "company_id" => company_id, "error_class" => e.class.name, "error_message" => e.message }
+    )
+  end
+end

--- a/app/models/concerns/company_quality_review.rb
+++ b/app/models/concerns/company_quality_review.rb
@@ -45,6 +45,10 @@ module CompanyQualityReview
     # reviewer queues instead of falling back into "not reviewed".
     scope :review_state_awaiting_contributor, -> { where(quality_status: CompanyReviewMarkService::RETURNED_STATUS) }
 
+    # The publishing workload: everything except records already decided (verified or
+    # rejected) and records parked with their contributor.
+    scope :needs_publishing_review, -> { where(quality_status: [nil, "", "needs_review"]) }
+
     scope :with_review_state, ->(state) {
       case state.to_s
       when "not_reviewed" then review_state_not_reviewed

--- a/app/services/agent_review_packet.rb
+++ b/app/services/agent_review_packet.rb
@@ -1,0 +1,158 @@
+# Everything a reviewer needs from one agent-review or duplicate-review run, so the
+# findings can be rendered wherever the reviewer happens to be.
+#
+# The results used to be reachable only from their own page, which meant running a
+# review threw the reviewer out of the company draft they were working on. Wrapping the
+# run in a packet lets the company draft render the same findings inline, and keeps the
+# apply rules in one place rather than duplicated per view.
+class AgentReviewPacket
+  # Bookkeeping fields. Applying them never changes public text.
+  METADATA_APPLY_FIELDS = %w[
+    quality_status
+    verification_verdict
+    quality_score
+    canonical_domain
+    fingerprint
+  ].freeze
+
+  # Public-text fields, written only through applicable_description.
+  CONTENT_APPLY_FIELDS = %w[description].freeze
+
+  APPLY_FIELDS = (METADATA_APPLY_FIELDS + CONTENT_APPLY_FIELDS).freeze
+
+  # Run types that carry reviewer-facing findings, newest first per company.
+  AGENT_REVIEW_TYPES = %w[company_agent_review company_review].freeze
+  DUPLICATE_REVIEW_TYPES = %w[duplicate_domain_review].freeze
+
+  def self.latest_agent_review_for(company)
+    wrap(PipelineRun.for_company(company).where(run_type: AGENT_REVIEW_TYPES).recent.first)
+  end
+
+  def self.latest_duplicate_review_for(company)
+    wrap(PipelineRun.for_company(company).where(run_type: DUPLICATE_REVIEW_TYPES).recent.first)
+  end
+
+  def self.wrap(pipeline_run)
+    pipeline_run && new(pipeline_run)
+  end
+
+  def initialize(pipeline_run)
+    @pipeline_run = pipeline_run
+  end
+
+  attr_reader :pipeline_run
+
+  def id = pipeline_run.id
+  def name = pipeline_run.name
+  def status = pipeline_run.status
+  def created_at = pipeline_run.created_at
+  def details = @details ||= pipeline_run.details || {}
+
+  def company = @company ||= Company.find_by(id: details["company_id"])
+  def evidence = Array(details["evidence"])
+  def tool_results = details["tool_results"] || {}
+  def description_draft = details["description_draft"] || {}
+  def description_critic = details["description_critic"] || {}
+  def review_coordinator = details["review_coordinator"] || {}
+  def duplicate_review = details["duplicate_review"] || {}
+  def risks = Array(details["risks"])
+  def admin_decision = details["admin_decision"]
+  def proposed_corrections = details["proposed_corrections"] || details["proposed_changes"] || {}
+
+  def findings? = review_coordinator.present? || description_draft.present? || evidence.any?
+  def duplicate_findings? = duplicate_review.present?
+
+  # ---- what an admin may apply from here ---------------------------------
+
+  def applicable_corrections
+    resolve_corrections
+    @applicable_corrections
+  end
+
+  def description_apply_source
+    resolve_corrections
+    @description_apply_source
+  end
+
+  def description_apply_block
+    resolve_corrections
+    @description_apply_block
+  end
+
+  def review_only_corrections
+    resolve_corrections
+    @review_only_corrections
+  end
+
+  private
+
+  # Split the packet's proposed corrections into what an admin can apply (keyed by
+  # company attribute) and what stays informational. The description is resolved
+  # separately because which string is authorised depends on the critic verdict, and
+  # because a blocked description must explain itself rather than silently vanish.
+  def resolve_corrections
+    return if defined?(@applicable_corrections)
+
+    @applicable_corrections = proposed_corrections.slice(*METADATA_APPLY_FIELDS)
+    @description_apply_source = nil
+    @description_apply_block = nil
+
+    candidate = applicable_description
+    if candidate
+      @applicable_corrections["description"] = candidate[:value]
+      @description_apply_source = candidate[:source]
+    end
+
+    @review_only_corrections = proposed_corrections.except(*METADATA_APPLY_FIELDS, "proposed_description")
+    @review_only_corrections["proposed_description"] = proposed_corrections["proposed_description"] if proposed_corrections.key?("proposed_description") && candidate.nil?
+  end
+
+  # The description string this packet authorises an admin to publish, or nil with
+  # description_apply_block set to the reason. Two gates, both required:
+  #
+  #   1. The stored critic verdict must name a specific string — the draft when the
+  #      critic passed it, the critic's own narrower rewrite when it asked for a
+  #      revision. A missing or rejecting verdict authorises nothing.
+  #   2. That exact string must then clear the same deterministic description gate the
+  #      publish path enforces, computed live. A stored verdict alone is never
+  #      sufficient: the packet may predate later prompt or gate changes, and the text
+  #      is about to become public.
+  def applicable_description
+    candidate = critic_authorised_description
+    return nil if candidate.nil?
+
+    verdict = CompanyProposalEnrichmentService.description_critic_for(candidate[:value])
+    return candidate if verdict["verdict"] == "pass"
+
+    issues = Array(verdict["issues"]).map(&:to_s).map(&:downcase).to_sentence.presence
+    @description_apply_block = if issues
+      "The #{candidate[:source]} does not clear the publication gate (#{issues}). Edit the company description directly instead."
+    else
+      "The #{candidate[:source]} does not clear the publication gate. Edit the company description directly instead."
+    end
+    nil
+  end
+
+  def critic_authorised_description
+    proposed = proposed_corrections["proposed_description"].to_s.strip
+    suggested = description_critic["suggested_revision"].to_s.strip
+    verdict = description_critic["verdict"].to_s
+
+    case verdict
+    when "pass"
+      return { value: proposed, source: "critic-approved draft" } if proposed.present?
+
+      @description_apply_block = "The critic passed this record but no proposed description was recorded."
+    when "revise"
+      return { value: suggested, source: "critic's suggested revision" } if suggested.present?
+
+      @description_apply_block = "The critic asked for a revision but did not supply replacement text. Revise the description by hand."
+    when ""
+      @description_apply_block = "No description critic verdict is recorded on this review, so no description can be applied. Re-run the review first." if proposed.present?
+    else
+      @description_apply_block = "The critic returned #{verdict}, so its draft cannot be published. Revise the description by hand."
+    end
+
+    nil
+  end
+end

--- a/app/views/admin/agent_reviews/_apply_corrections.html.slim
+++ b/app/views/admin/agent_reviews/_apply_corrections.html.slim
@@ -1,0 +1,51 @@
+/ The apply control. Usable from the standalone review page and from the company draft.
+/ Locals: packet (AgentReviewPacket), return_to (nil or "company")
+
+.card.border-0.shadow-sm.mb-3
+    .card-header.bg-white.py-2
+        h2.h6.mb-0 Apply corrections
+    .card-body.py-3
+        - if packet.company.blank?
+            p.text-muted.small.mb-0 This review is not linked to a company.
+        - elsif packet.applicable_corrections.present?
+            = form_with url: apply_custom_admin_agent_review_path(packet.pipeline_run), method: :post, local: true do
+                = hidden_field_tag :return_to, return_to if return_to.present?
+                .table-responsive.mb-3
+                    table.table.table-sm.align-middle
+                        thead
+                            tr
+                                th Apply
+                                th Field
+                                th Current
+                                th Proposed
+                        tbody
+                            - packet.applicable_corrections.each do |field, value|
+                                tr
+                                    td= check_box_tag "fields[]", field, true, id: "field_#{field}_#{packet.id}"
+                                    td
+                                        label.form-check-label for="field_#{field}_#{packet.id}"= field.humanize
+                                        - if field == "description" && packet.description_apply_source.present?
+                                            .text-muted.small= packet.description_apply_source.capitalize
+                                    td.text-muted= truncate(packet.company.public_send(field).to_s, length: 140).presence || "Blank"
+                                    td.fw-semibold= truncate(value.to_s, length: 240).presence || "Blank"
+                = submit_tag "Apply selected corrections", class: "btn btn-primary w-100", data: { turbo_confirm: "Apply the selected corrections to this company?" }
+        - else
+            p.text-muted.small.mb-0 No corrections from this review can be applied.
+
+        - if packet.description_apply_block.present?
+            .alert.alert-warning.py-2.small.mt-3.mb-0
+                strong.d-block.mb-1 Description not applied
+                = packet.description_apply_block
+                - if packet.company
+                    = " "
+                    = link_to "Edit the company", edit_custom_admin_company_path(packet.company.id), class: "fw-semibold"
+
+        .d-grid.gap-2.mt-3
+            = button_to "Reject review output", reject_custom_admin_agent_review_path(packet.pipeline_run), method: :post, params: { return_to: return_to }.compact, class: "btn btn-outline-danger btn-sm", form: { data: { turbo_confirm: "Reject this review output without changing company data?" } }
+            = button_to "Mark needs follow-up", follow_up_custom_admin_agent_review_path(packet.pipeline_run), method: :post, params: { return_to: return_to }.compact, class: "btn btn-outline-secondary btn-sm"
+
+        - if packet.review_only_corrections.present?
+            .alert.alert-secondary.mt-3.mb-0.small
+                strong Context only:
+                = " #{packet.review_only_corrections.keys.map(&:humanize).to_sentence}."
+                |  These record the agents' reasoning rather than values to write.

--- a/app/views/admin/agent_reviews/_duplicate_findings.html.slim
+++ b/app/views/admin/agent_reviews/_duplicate_findings.html.slim
@@ -1,0 +1,50 @@
+/ Duplicate-review findings, rendered wherever the reviewer is.
+/ Locals: packet (AgentReviewPacket)
+
+- duplicate_review = packet.duplicate_review
+- recommendation = duplicate_review["overall_recommendation"].presence || "not run"
+.card.border-0.shadow-sm.mb-3
+    .card-header.bg-white.d-flex.justify-content-between.align-items-center
+        h2.h5.mb-0 Duplicate review
+        - if recommendation == "likely_duplicate_group"
+            span.badge.bg-danger= recommendation.humanize
+        - elsif recommendation == "likely_distinct"
+            span.badge.bg-success= recommendation.humanize
+        - else
+            span.badge.bg-warning.text-dark= recommendation.humanize
+    .card-body
+        - if duplicate_review.present?
+            - if duplicate_review["rationale"].present?
+                p.mb-3= duplicate_review["rationale"]
+            - if Array(duplicate_review["pair_reviews"]).any?
+                .table-responsive.mb-3
+                    table.table.table-sm.align-middle.mb-0
+                        thead
+                            tr
+                                th Compared with
+                                th Relationship
+                                th Confidence
+                                th Reasons
+                        tbody
+                            - Array(duplicate_review["pair_reviews"]).each do |review|
+                                - candidate = Company.find_by(id: review["candidate_company_id"])
+                                tr
+                                    td
+                                        - if candidate
+                                            = link_to "#{candidate.name} (##{candidate.id})", custom_admin_company_review_path(candidate.id)
+                                        - else
+                                            = review["candidate_company_id"]
+                                    td
+                                        span.badge.text-bg-light= review["relationship"].to_s.humanize
+                                    td= review["confidence"].to_s.humanize
+                                    td
+                                        ul.small.mb-0
+                                            - Array(review["reasons"]).each do |reason|
+                                                li= reason
+            - if Array(duplicate_review["unresolved_questions"]).any?
+                .text-uppercase.text-muted.small.fw-semibold Unresolved questions
+                ul.mb-0
+                    - Array(duplicate_review["unresolved_questions"]).each do |question|
+                        li= question
+        - else
+            p.text-muted.mb-0 No duplicate review output recorded.

--- a/app/views/admin/agent_reviews/_findings.html.slim
+++ b/app/views/admin/agent_reviews/_findings.html.slim
@@ -1,0 +1,92 @@
+/ Agent-review findings. Rendered on the standalone review page and inline on the
+/ company draft, so running a review never costs the reviewer their place.
+/ Locals: packet (AgentReviewPacket)
+
+- coordinator = packet.review_coordinator
+- coordinator_status = coordinator["status"].presence || "not run"
+.card.border-0.shadow-sm.mb-3
+    .card-header.bg-white.d-flex.justify-content-between.align-items-center
+        h2.h5.mb-0 What the review found
+        - if coordinator_status == "ready_for_human_review"
+            span.badge.bg-success= coordinator_status.humanize
+        - elsif coordinator_status == "do_not_publish"
+            span.badge.bg-danger= coordinator_status.humanize
+        - else
+            span.badge.bg-warning.text-dark= coordinator_status.humanize
+    .card-body
+        - if coordinator.present?
+            - if Array(coordinator["reasons"]).any?
+                .text-uppercase.text-muted.small.fw-semibold Why
+                ul.mb-3
+                    - Array(coordinator["reasons"]).each do |reason|
+                        li= reason
+            - if Array(coordinator["disagreements"]).any?
+                .text-uppercase.text-muted.small.fw-semibold Where the agents disagreed
+                ul.mb-3
+                    - Array(coordinator["disagreements"]).each do |disagreement|
+                        li= disagreement
+            - if Array(coordinator["recommended_actions"]).any?
+                .text-uppercase.text-muted.small.fw-semibold Suggested next steps
+                ul.mb-3
+                    - Array(coordinator["recommended_actions"]).each do |action|
+                        li= action
+        - else
+            p.text-muted.mb-0 No coordinator output recorded.
+
+- if packet.description_draft.present? || packet.proposed_corrections["proposed_description"].present?
+    .card.border-0.shadow-sm.mb-3
+        .card-header.bg-white.d-flex.justify-content-between.align-items-center
+            h2.h5.mb-0 Description
+            - if packet.applicable_corrections.key?("description")
+                span.badge.bg-success Ready to apply
+            - else
+                span.badge.bg-warning.text-dark Review only
+        .card-body
+            - if packet.company
+                .mb-3
+                    .text-uppercase.text-muted.small.fw-semibold Current
+                    p.mb-0= packet.company.description.presence || "Blank"
+            .mb-3
+                .text-uppercase.text-muted.small.fw-semibold Proposed
+                p.mb-0.fw-semibold= packet.description_draft["proposed_description"].presence || packet.proposed_corrections["proposed_description"].presence || "No proposed description recorded."
+            - critic = packet.description_critic
+            - if critic.present?
+                .border-top.pt-2
+                    .d-flex.align-items-center.gap-2.mb-1
+                        .text-uppercase.text-muted.small.fw-semibold Critic
+                        - if critic["verdict"] == "pass"
+                            span.badge.bg-success Pass
+                        - else
+                            span.badge.bg-warning.text-dark= critic["verdict"].to_s.humanize.presence || "Not run"
+                    - if critic["rationale"].present?
+                        p.small.text-muted.mb-1= critic["rationale"]
+                    - if Array(critic["issues"]).any?
+                        ul.small.mb-1
+                            - Array(critic["issues"]).each do |issue|
+                                li= issue
+                    - if critic["suggested_revision"].present?
+                        .small
+                            .text-uppercase.text-muted.small.fw-semibold Suggested revision
+                            p.mb-0= critic["suggested_revision"]
+
+- if packet.evidence.any?
+    .card.border-0.shadow-sm.mb-3
+        .card-header.bg-white.py-2
+            h2.h6.mb-0 Evidence used
+        .card-body.py-3
+            ul.small.mb-0
+                - packet.evidence.each do |item|
+                    li
+                        - if item["url"].present?
+                            = link_to item["title"].presence || item["url"], item["url"], target: "_blank", rel: "noopener"
+                        - else
+                            = item["title"]
+                        - if item["summary"].present?
+                            .text-muted= item["summary"]
+
+- if packet.risks.any?
+    .alert.alert-warning.py-2.small.mb-3
+        strong.d-block.mb-1 Risks flagged
+        ul.mb-0
+            - packet.risks.each do |risk|
+                li= risk

--- a/app/views/admin/agent_reviews/show.html.slim
+++ b/app/views/admin/agent_reviews/show.html.slim
@@ -4,23 +4,28 @@
     div
         h1.h3.mb-1= @pipeline_run.name
         p.text-muted.mb-0 Review the evidence, apply the corrections you agree with, or reject and follow up without changing the record.
-    = link_to "Back to activity", custom_admin_pipeline_runs_path(activity: "agent_reviews"), class: "btn btn-outline-secondary"
+    .d-flex.gap-2
+        - if @company
+            = link_to custom_admin_company_review_path(@company.id), class: "btn btn-primary" do
+                i.fas.fa-arrow-left.me-1
+                | Back to company draft
+        = link_to "Activity", custom_admin_pipeline_runs_path(activity: "agent_reviews"), class: "btn btn-outline-secondary"
 
 .alert.alert-info
     strong You decide what gets applied.
     |  Nothing here changes the company until you select it. A proposed description can only be applied when the critic has approved specific wording, and it is re-checked against the publication gate at the moment you apply it.
 
-- if @details["admin_decision"].present?
+- if @packet.admin_decision.present?
     .alert.alert-secondary
         strong Admin decision:
-        = " #{@details['admin_decision']['decision'].to_s.humanize}"
-        span= " by #{@details['admin_decision']['admin_user_email']} at #{@details['admin_decision']['decided_at']}"
+        = " #{@packet.admin_decision['decision'].to_s.humanize}"
+        span= " by #{@packet.admin_decision['admin_user_email']} at #{@packet.admin_decision['decided_at']}"
 
 .row.g-3
     .col-lg-7
         .card.border-0.shadow-sm.mb-3
             .card-header.bg-white
-                h2.h5.mb-0 Linked Company
+                h2.h5.mb-0 Linked company
             .card-body
                 - if @company
                     .fw-semibold= link_to @company.name, custom_admin_company_review_path(@company.id)
@@ -28,235 +33,19 @@
                 - else
                     p.text-muted.mb-0 This agent output is not linked to a company.
 
-        .card.border-0.shadow-sm.mb-3
-            .card-header.bg-white.d-flex.justify-content-between.align-items-center
-                h2.h5.mb-0 Review Coordinator
-                - coordinator_status = @review_coordinator["status"].presence || "not run"
-                - if coordinator_status == "ready_for_human_review"
-                    span.badge.bg-success= coordinator_status.humanize
-                - elsif coordinator_status == "do_not_publish"
-                    span.badge.bg-danger= coordinator_status.humanize
-                - else
-                    span.badge.bg-warning.text-dark= coordinator_status.humanize
-            .card-body
-                - if @review_coordinator.present?
-                    - if Array(@review_coordinator["reasons"]).any?
-                        .text-uppercase.text-muted.small.fw-semibold Reasons
-                        ul.mb-3
-                            - Array(@review_coordinator["reasons"]).each do |reason|
-                                li= reason
-                    - if Array(@review_coordinator["disagreements"]).any?
-                        .text-uppercase.text-muted.small.fw-semibold Disagreements
-                        ul.mb-3
-                            - Array(@review_coordinator["disagreements"]).each do |disagreement|
-                                li= disagreement
-                    - if Array(@review_coordinator["recommended_actions"]).any?
-                        .text-uppercase.text-muted.small.fw-semibold Recommended actions
-                        ul.mb-3
-                            - Array(@review_coordinator["recommended_actions"]).each do |action|
-                                li= action
-                    .text-muted.small= "Coordinator mode: #{@review_coordinator['mode']}" if @review_coordinator["mode"].present?
-                - else
-                    p.text-muted.mb-0 No coordinator output recorded.
+        == render partial: "admin/agent_reviews/findings", locals: { packet: @packet }
+        - if @packet.duplicate_findings?
+            == render partial: "admin/agent_reviews/duplicate_findings", locals: { packet: @packet }
 
-        .card.border-0.shadow-sm.mb-3
-            .card-header.bg-white.d-flex.justify-content-between.align-items-center
-                h2.h5.mb-0 Duplicate Review
-                - duplicate_recommendation = @duplicate_review["overall_recommendation"].presence || "not run"
-                - if duplicate_recommendation == "likely_duplicate_group"
-                    span.badge.bg-danger= duplicate_recommendation.humanize
-                - elsif duplicate_recommendation == "likely_distinct"
-                    span.badge.bg-success= duplicate_recommendation.humanize
-                - else
-                    span.badge.bg-warning.text-dark= duplicate_recommendation.humanize
-            .card-body
-                - if @duplicate_review.present?
-                    - if @duplicate_review["rationale"].present?
-                        p.mb-3= @duplicate_review["rationale"]
-                    - if Array(@duplicate_review["pair_reviews"]).any?
-                        .table-responsive.mb-3
-                            table.table.table-sm.align-middle.mb-0
-                                thead
-                                    tr
-                                        th Candidate
-                                        th Relationship
-                                        th Confidence
-                                        th Reasons
-                                tbody
-                                    - Array(@duplicate_review["pair_reviews"]).each do |review|
-                                        tr
-                                            td= review["candidate_company_id"]
-                                            td
-                                                span.badge.text-bg-light= review["relationship"].to_s.humanize
-                                            td= review["confidence"].to_s.humanize
-                                            td
-                                                ul.mb-0
-                                                    - Array(review["reasons"]).each do |reason|
-                                                        li= reason
-                    - if Array(@duplicate_review["unresolved_questions"]).any?
-                        .text-uppercase.text-muted.small.fw-semibold Unresolved questions
-                        ul.mb-3
-                            - Array(@duplicate_review["unresolved_questions"]).each do |question|
-                                li= question
-                    .text-muted.small= "Duplicate review mode: #{@duplicate_review['mode']}" if @duplicate_review["mode"].present?
-                - else
-                    p.text-muted.mb-0 No duplicate review output recorded.
-
-        .card.border-0.shadow-sm.mb-3
-            .card-header.bg-white.d-flex.justify-content-between.align-items-center
-                h2.h5.mb-0 Description Draft
-                - if @applicable_corrections&.key?("description")
-                    span.badge.bg-success Ready to apply
-                - else
-                    span.badge.bg-warning.text-dark Review only
-            .card-body
-                - if @company
-                    .mb-3
-                        .text-uppercase.text-muted.small.fw-semibold Current description
-                        p.mb-0= @company.description.presence || "Blank"
-                    .mb-3
-                        .text-uppercase.text-muted.small.fw-semibold Proposed description
-                        p.mb-0.fw-semibold= @description_draft["proposed_description"].presence || @proposed_corrections["proposed_description"].presence || "No proposed description recorded."
-                    - if @description_draft["rationale"].present?
-                        .text-muted.small= @description_draft["rationale"]
-                    - if @description_draft["mode"].present?
-                        .text-muted.small= "Draft mode: #{@description_draft['mode']}"
-                - else
-                    p.text-muted.mb-0 This review is not linked to a company.
-
-        .card.border-0.shadow-sm.mb-3
-            .card-header.bg-white.d-flex.justify-content-between.align-items-center
-                h2.h5.mb-0 Description Critic
-                - critic_verdict = @description_critic["verdict"].presence || "not run"
-                - if critic_verdict == "pass"
-                    span.badge.bg-success= critic_verdict.humanize
-                - else
-                    span.badge.bg-warning.text-dark= critic_verdict.humanize
-            .card-body
-                - if @description_critic.present?
-                    - if @description_critic["rationale"].present?
-                        p.mb-3= @description_critic["rationale"]
-                    - if Array(@description_critic["issues"]).any?
-                        .text-uppercase.text-muted.small.fw-semibold Issues
-                        ul.mb-3
-                            - Array(@description_critic["issues"]).each do |issue|
-                                li= issue
-                    - else
-                        p.text-muted.mb-3 No critic issues recorded.
-                    - if @description_critic["suggested_revision"].present?
-                        .text-uppercase.text-muted.small.fw-semibold Suggested revision
-                        p.mb-3.fw-semibold= @description_critic["suggested_revision"]
-                    .text-muted.small= "Critic mode: #{@description_critic['mode']}" if @description_critic["mode"].present?
-                - else
-                    p.text-muted.mb-0 No critic output recorded.
-
-        .card.border-0.shadow-sm.mb-3
-            .card-header.bg-white
-                h2.h5.mb-0 Evidence
-            .card-body
-                - if @evidence.any?
-                    .list-group.list-group-flush
-                        - @evidence.each do |item|
-                            .list-group-item.px-0
-                                - if item.is_a?(Hash)
-                                    .fw-semibold= item["title"].presence || item["source"].presence || "Evidence item"
-                                    - if item["url"].present?
-                                        = link_to item["url"], item["url"], target: "_blank", rel: "noopener"
-                                    - if item["summary"].present?
-                                        p.mb-0.mt-2= item["summary"]
-                                - else
-                                    = item
-                - else
-                    p.text-muted.mb-0 No evidence recorded.
-
-        .card.border-0.shadow-sm.mb-3
-            .card-header.bg-white
-                h2.h5.mb-0 Evidence Tools
-            .card-body
-                - if @tool_results.present?
-                    .accordion id="evidenceTools"
-                        - @tool_results.each_with_index do |(tool_name, result), index|
-                            .accordion-item
-                                h3.accordion-header id="toolHeading#{index}"
-                                    button.accordion-button.collapsed type="button" data-bs-toggle="collapse" data-bs-target="#toolCollapse#{index}" aria-expanded="false" aria-controls="toolCollapse#{index}"= tool_name.to_s.humanize
-                                .accordion-collapse.collapse id="toolCollapse#{index}" aria-labelledby="toolHeading#{index}" data-bs-parent="#evidenceTools"
-                                    .accordion-body
-                                        pre.bg-light.border.rounded.p-2.small.mb-0= JSON.pretty_generate(result)
-                - else
-                    p.text-muted.mb-0 No evidence tool output recorded.
-
-        .card.border-0.shadow-sm
-            .card-header.bg-white
-                h2.h5.mb-0 Risks
-            .card-body
-                - if @risks.any?
-                    ul.mb-0
-                        - @risks.each do |risk|
-                            li= risk
-                - else
-                    p.text-muted.mb-0 No risks recorded.
+        - if @packet.tool_results.present?
+            .card.border-0.shadow-sm
+                .card-header.bg-white.py-2
+                    button.btn.btn-link.btn-sm.text-decoration-none.text-dark.p-0.fw-semibold type="button" data-bs-toggle="collapse" data-bs-target="#agentReviewToolResults" aria-expanded="false" aria-controls="agentReviewToolResults"
+                        i.fas.fa-chevron-right.me-1
+                        | Technical details
+                #agentReviewToolResults.collapse
+                    .card-body.py-3.border-top
+                        pre.bg-light.border.rounded.p-2.small.mb-0= JSON.pretty_generate(@packet.tool_results)
 
     .col-lg-5
-        .card.border-0.shadow-sm.mb-3
-            .card-header.bg-white
-                h2.h5.mb-0 Apply corrections
-            .card-body
-                - if @company.blank?
-                    p.text-muted.mb-0 This review is not linked to a company.
-                - elsif @applicable_corrections.present?
-                    = form_with url: apply_custom_admin_agent_review_path(@pipeline_run), method: :post, local: true do
-                        .table-responsive.mb-3
-                            table.table.table-sm.align-middle
-                                thead
-                                    tr
-                                        th Apply
-                                        th Field
-                                        th Current
-                                        th Proposed
-                                tbody
-                                    - @applicable_corrections.each do |field, value|
-                                        tr
-                                            td= check_box_tag "fields[]", field, true, id: "field_#{field}"
-                                            td
-                                                label.form-check-label for="field_#{field}"= field.humanize
-                                                - if field == "description" && @description_apply_source.present?
-                                                    .text-muted.small= @description_apply_source.capitalize
-                                            td.text-muted= truncate(@company.public_send(field).to_s, length: 140).presence || "Blank"
-                                            td.fw-semibold= truncate(value.to_s, length: 240).presence || "Blank"
-                        = submit_tag "Apply selected corrections", class: "btn btn-primary w-100", data: { turbo_confirm: "Apply the selected corrections to this company?" }
-                - else
-                    p.text-muted.mb-0 No corrections from this review can be applied.
-
-                - if @description_apply_block.present?
-                    .alert.alert-warning.py-2.small.mt-3.mb-0
-                        strong.d-block.mb-1 Description not applied
-                        = @description_apply_block
-                        - if @company
-                            = " "
-                            = link_to "Edit the company", edit_custom_admin_company_path(@company.id), class: "fw-semibold"
-
-                .d-grid.gap-2.mt-3
-                    = button_to "Reject Review Output", reject_custom_admin_agent_review_path(@pipeline_run), method: :post, class: "btn btn-outline-danger", form: { data: { turbo_confirm: "Reject this agent review without changing company data?" } }
-                    = button_to "Mark Needs Follow-Up", follow_up_custom_admin_agent_review_path(@pipeline_run), method: :post, class: "btn btn-outline-secondary"
-
-        .card.border-0.shadow-sm
-            .card-header.bg-white
-                h2.h5.mb-0 Proposed Corrections
-            .card-body
-                - if @proposed_corrections.present?
-                    dl.mb-0
-                        - @proposed_corrections.each do |field, value|
-                            dt= field.to_s.humanize
-                            dd
-                                - if value.is_a?(Hash) || value.is_a?(Array)
-                                    pre.bg-light.border.rounded.p-2.small= JSON.pretty_generate(value)
-                                - else
-                                    = value
-                - else
-                    p.text-muted.mb-0 No proposed corrections recorded.
-
-                - if @review_only_proposed_corrections.present?
-                    .alert.alert-secondary.mt-3.mb-0.small
-                        strong Context only:
-                        = " #{@review_only_proposed_corrections.keys.map(&:humanize).to_sentence}."
-                        |  These record the agents' reasoning rather than values to write, so they are not offered above.
+        == render partial: "admin/agent_reviews/apply_corrections", locals: { packet: @packet, return_to: params[:return_to] }

--- a/app/views/admin/company_management/index.html.slim
+++ b/app/views/admin/company_management/index.html.slim
@@ -53,9 +53,15 @@
                         | Export CSV
             - if @active_filter_count.positive?
                 = link_to "Reset", custom_admin_companies_path, class: "btn btn-sm btn-link text-muted text-decoration-none"
+    .card-body.border-bottom.py-2
+        = form_with url: batch_agent_review_custom_admin_companies_path, method: :post, local: true, id: "company-batch-review-form", html: { data: { batch_form: true, batch_input: "company_ids[]" } } do
+            .admin-proposal-batch-actions.d-none data-batch-actions=""
+                span.text-muted.small.me-2= "Runs an agent review on each selected record, up to #{Admin::CompanyManagementController::BATCH_REVIEW_LIMIT}. Nothing is approved, published or rejected."
+                = submit_tag "Run agent review", class: "btn btn-sm btn-outline-primary rounded-pill px-3", data: { turbo_confirm: "Queue an agent review for each selected company?" }
     .table-responsive
         table.table.table-hover.align-middle.mb-0.admin-table.is-compact.is-company-list
             colgroup
+                col.admin-col-checkbox
                 col.admin-col-company
                 col.admin-col-url
                 col.admin-col-category
@@ -66,6 +72,7 @@
                 col.admin-col-actions
             thead
                 tr
+                    th.admin-table-checkbox-col= check_box_tag :select_all_companies, "1", false, class: "form-check-input", form: "company-batch-review-form", data: { batch_select_all: true }, aria: { label: "Select all companies on this page" }
                     th Company
                     th URL
                     th.admin-nowrap Category
@@ -85,6 +92,7 @@
                     - issue_chips << { label: "Duplicate name", tone: "danger" } if @duplicate_name_company_ids.include?(company.id)
                     - issue_chips << { label: "Unknown taxonomy", tone: "muted" } if taxonomy_unknown
                     tr
+                        td.admin-table-checkbox-col= check_box_tag "company_ids[]", company.id, false, class: "form-check-input", form: "company-batch-review-form", aria: { label: "Select #{company.name}" }
                         td.admin-description
                             = link_to custom_admin_company_review_path(company.id), class: "admin-primary-link", aria: { label: "Review #{company.name}" } do
                                 .admin-company-cell
@@ -133,5 +141,7 @@
                                         | Delete
                 - if @companies.empty?
                     tr
-                        td.text-muted.text-center colspan="8" No companies match these filters.
+                        td.text-muted.text-center colspan="9" No companies match these filters.
     = render "shared/pagination", collection: @companies, count_label: "companies", wrapper_class: "card-footer bg-white app-pagination-footer"
+
+= render "shared/batch_selection_script"

--- a/app/views/admin/company_proposals/index.html.slim
+++ b/app/views/admin/company_proposals/index.html.slim
@@ -1,6 +1,6 @@
 - content_for :title, "Review"
 
-= form_with url: batch_custom_admin_company_proposals_path, method: :post, local: true, html: { data: { proposal_batch_form: true } } do
+= form_with url: batch_custom_admin_company_proposals_path, method: :post, local: true, html: { data: { batch_form: true, batch_input: "proposal_ids[]" } } do
     = hidden_field_tag :status, @status
     .card.border-0.shadow-sm.admin-compact-card
         .card-header.bg-white
@@ -14,7 +14,7 @@
             .admin-filter-toolbar
                 - @status_counts.each do |status, count|
                     = link_to "#{status.humanize} #{number_with_delimiter(count)}", custom_admin_company_proposals_path(status: status), class: "btn btn-sm #{@status == status ? 'btn-primary' : 'btn-outline-secondary'} rounded-pill px-3"
-                .admin-proposal-batch-actions.d-none data-proposal-batch-actions=""
+                .admin-proposal-batch-actions.d-none data-batch-actions=""
                     = button_tag "Re-enrich selected", type: "submit", name: "batch_action", value: "reenrich", class: "btn btn-sm btn-outline-primary rounded-pill px-3"
                     = button_tag "Mark needs revision", type: "submit", name: "batch_action", value: "mark_needs_revision", class: "btn btn-sm btn-outline-warning rounded-pill px-3"
                     = button_tag "Publish selected", type: "submit", name: "batch_action", value: "publish", class: "btn btn-sm btn-success rounded-pill px-3", data: { turbo_confirm: "Only publish proposals that pass all readiness gates?" }
@@ -22,7 +22,7 @@
             table.table.table-hover.align-middle.mb-0.admin-table.is-compact
                 thead
                     tr
-                        th.admin-table-checkbox-col= check_box_tag :select_all_proposals, "1", false, class: "form-check-input", data: { proposal_select_all: true }, aria: { label: "Select all proposals on this page" }
+                        th.admin-table-checkbox-col= check_box_tag :select_all_proposals, "1", false, class: "form-check-input", data: { batch_select_all: true }, aria: { label: "Select all proposals on this page" }
                         th Candidate
                         th.admin-nowrap Readiness
                         th Issues
@@ -85,56 +85,4 @@
                             td.text-muted colspan="6" No proposals in this queue.
         = render "shared/pagination", collection: @company_proposals, count_label: "proposals", wrapper_class: "card-footer bg-white app-pagination-footer"
 
-javascript:
-    (function() {
-        function updateSelectAllState(selectAll, checkboxes) {
-            if (!selectAll) return;
-            let checkedCount = Array.from(checkboxes).filter(function(checkbox) { return checkbox.checked; }).length;
-            selectAll.checked = checkboxes.length > 0 && checkedCount === checkboxes.length;
-            selectAll.indeterminate = checkedCount > 0 && checkedCount < checkboxes.length;
-        }
-
-        function updateBatchActionsVisibility(batchActions, checkboxes) {
-            if (!batchActions) return;
-            let anyChecked = Array.from(checkboxes).some(function(checkbox) { return checkbox.checked; });
-            batchActions.classList.toggle("d-none", !anyChecked);
-        }
-
-        function bindProposalBatchForm(form) {
-            if (form.dataset.proposalBatchBound) return;
-            form.dataset.proposalBatchBound = "true";
-
-            let batchActions = form.querySelector("[data-proposal-batch-actions]");
-            let checkboxes = form.querySelectorAll('input[name="proposal_ids[]"]');
-            let selectAll = form.querySelector("[data-proposal-select-all]");
-
-            function refreshState() {
-                updateBatchActionsVisibility(batchActions, checkboxes);
-                updateSelectAllState(selectAll, checkboxes);
-            }
-
-            checkboxes.forEach(function(checkbox) {
-                checkbox.addEventListener("change", refreshState);
-            });
-
-            if (selectAll) {
-                selectAll.addEventListener("change", function() {
-                    checkboxes.forEach(function(checkbox) {
-                        checkbox.checked = selectAll.checked;
-                    });
-                    selectAll.indeterminate = false;
-                    refreshState();
-                });
-            }
-
-            refreshState();
-        }
-
-        function bindProposalBatchForms() {
-            document.querySelectorAll("[data-proposal-batch-form]").forEach(bindProposalBatchForm);
-        }
-
-        document.addEventListener("turbo:load", bindProposalBatchForms);
-        document.addEventListener("turbo:render", bindProposalBatchForms);
-        bindProposalBatchForms();
-    })();
+= render "shared/batch_selection_script"

--- a/app/views/admin/company_reviews/show.html.slim
+++ b/app/views/admin/company_reviews/show.html.slim
@@ -223,6 +223,57 @@
                     dt.col-sm-3 Longitude
                     dd.col-sm-9= field_value.call(@company.longitude)
 
+        / Quality-control findings, inline. Running either review reloads this page at
+        / the section it filled in, so the reviewer never leaves the draft.
+        #agent-review.mt-3
+            .d-flex.flex-wrap.justify-content-between.align-items-center.gap-2.mb-2
+                h2.h5.mb-0 Agent review
+                .d-flex.align-items-center.gap-2
+                    - if @agent_review
+                        span.text-muted.small= "Last run #{time_ago_in_words(@agent_review.created_at)} ago"
+                    = button_to(@agent_review ? "Run again" : "Run agent review", custom_admin_company_agent_review_path(@company.id), method: :post, class: "btn btn-sm btn-outline-primary", form: { data: { turbo_confirm: "Run an agent review for #{@company.name}? Nothing is changed until you apply it." } })
+            - if @agent_review&.findings?
+                == render partial: "admin/agent_reviews/findings", locals: { packet: @agent_review }
+                == render partial: "admin/agent_reviews/apply_corrections", locals: { packet: @agent_review, return_to: "company" }
+                p.text-muted.small
+                    = link_to "Open the full review packet", custom_admin_agent_review_path(@agent_review.pipeline_run)
+            - else
+                .card.border-0.shadow-sm.mb-3
+                    .card-body.py-3
+                        p.text-muted.small.mb-0 No agent review has been run for this record yet.
+
+        #duplicate-review
+            .d-flex.flex-wrap.justify-content-between.align-items-center.gap-2.mb-2
+                h2.h5.mb-0 Duplicate review
+                .d-flex.align-items-center.gap-2
+                    - if @duplicate_review
+                        span.text-muted.small= "Last run #{time_ago_in_words(@duplicate_review.created_at)} ago"
+                    = button_to(@duplicate_review ? "Run again" : "Run duplicate review", custom_admin_company_duplicate_review_path(@company.id), method: :post, class: "btn btn-sm btn-outline-primary", form: { data: { turbo_confirm: "Run a duplicate review for #{@company.name}?" } })
+            - if @duplicate_review&.duplicate_findings?
+                == render partial: "admin/agent_reviews/duplicate_findings", locals: { packet: @duplicate_review }
+            - else
+                .card.border-0.shadow-sm.mb-3
+                    .card-body.py-3
+                        p.text-muted.small.mb-0
+                            | No duplicate review has been run for this record. The deterministic Duplicate Check in the sidebar runs on every page load regardless.
+
+        / Reviewer decision, at the end of the reading order Hafez asked for. The same
+        / controls also sit in the header for a reviewer who has already made up their mind.
+        .card.border-0.shadow-sm.mb-3
+            .card-header.bg-white.py-2
+                h2.h5.mb-0 Reviewer decision
+            .card-body.py-3
+                .d-flex.flex-wrap.gap-2
+                    = button_to custom_admin_company_mark_review_path(@company.id), method: :post, params: { decision: "verified" }, class: "btn btn-success", form: { data: { turbo_confirm: "Mark #{@company.name} as verified?" } } do
+                        i.fas.fa-check.me-1
+                        | Mark verified
+                    = button_to custom_admin_company_mark_review_path(@company.id), method: :post, params: { decision: "needs_work" }, class: "btn btn-outline-secondary", form: { data: { turbo_confirm: "Mark #{@company.name} as needing more review?" } } do
+                        | Needs more work
+                    button.btn.btn-outline-warning type="button" data-bs-toggle="collapse" data-bs-target="#returnToContributorPanel" aria-expanded="false" aria-controls="returnToContributorPanel"
+                        | Return to contributor
+                    = button_to custom_admin_company_mark_review_path(@company.id), method: :post, params: { decision: "reject" }, class: "btn btn-outline-danger", form: { data: { turbo_confirm: "Reject and hide #{@company.name}?" } } do
+                        | Reject and hide
+
     .col-lg-4
         .card.border-0.shadow-sm.mb-3
             .card-header.bg-white

--- a/app/views/shared/_batch_selection_script.html.slim
+++ b/app/views/shared/_batch_selection_script.html.slim
@@ -1,0 +1,66 @@
+/ Row-selection behaviour for any admin batch form. Shared so the proposal queue and
+/ the company queue do not carry two copies of the same script.
+/
+/ A form opts in with data-batch-form and data-batch-input="<checkbox name>"; the
+/ select-all box carries data-batch-select-all, and the action bar data-batch-actions.
+javascript:
+    (function() {
+        function updateSelectAllState(selectAll, checkboxes) {
+            if (!selectAll) return;
+            let checkedCount = Array.from(checkboxes).filter(function(checkbox) { return checkbox.checked; }).length;
+            selectAll.checked = checkboxes.length > 0 && checkedCount === checkboxes.length;
+            selectAll.indeterminate = checkedCount > 0 && checkedCount < checkboxes.length;
+        }
+
+        function updateBatchActionsVisibility(batchActions, checkboxes) {
+            if (!batchActions) return;
+            let anyChecked = Array.from(checkboxes).some(function(checkbox) { return checkbox.checked; });
+            batchActions.classList.toggle("d-none", !anyChecked);
+        }
+
+        function bindBatchForm(form) {
+            if (form.dataset.batchBound) return;
+            form.dataset.batchBound = "true";
+
+            let inputName = form.dataset.batchInput;
+            if (!inputName) return;
+
+            let batchActions = form.querySelector("[data-batch-actions]");
+            // Checkboxes may live inside the form, or outside it and joined by the HTML5
+            // `form` attribute — the company list does the latter, because its rows
+            // already contain button_to forms and HTML forbids nesting them.
+            let checkboxes = Array.from(document.querySelectorAll('input[name="' + inputName + '"]'))
+                .filter(function(checkbox) { return checkbox.form === form; });
+            let selectAll = Array.from(document.querySelectorAll("[data-batch-select-all]"))
+                .find(function(box) { return box.form === form; }) || form.querySelector("[data-batch-select-all]");
+
+            function refreshState() {
+                updateBatchActionsVisibility(batchActions, checkboxes);
+                updateSelectAllState(selectAll, checkboxes);
+            }
+
+            checkboxes.forEach(function(checkbox) {
+                checkbox.addEventListener("change", refreshState);
+            });
+
+            if (selectAll) {
+                selectAll.addEventListener("change", function() {
+                    checkboxes.forEach(function(checkbox) {
+                        checkbox.checked = selectAll.checked;
+                    });
+                    selectAll.indeterminate = false;
+                    refreshState();
+                });
+            }
+
+            refreshState();
+        }
+
+        function bindBatchForms() {
+            document.querySelectorAll("[data-batch-form]").forEach(bindBatchForm);
+        }
+
+        document.addEventListener("turbo:load", bindBatchForms);
+        document.addEventListener("turbo:render", bindBatchForms);
+        bindBatchForms();
+    })();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
   patch 'admin/app/resources/:resource/:id', to: 'admin/resources#update', as: :custom_admin_resource_record
   delete 'admin/app/resources/:resource/:id', to: 'admin/resources#destroy'
   get 'admin/app/companies', to: 'admin/company_management#index', as: :custom_admin_companies
+  post 'admin/app/companies/batch-agent-review', to: 'admin/company_management#batch_agent_review', as: :batch_agent_review_custom_admin_companies
   get 'admin/app/companies/new', to: 'admin/company_management#new', as: :new_custom_admin_company
   post 'admin/app/companies/fill-from-url', to: 'admin/company_management#fill_from_url', as: :fill_from_url_custom_admin_company
   post 'admin/app/companies', to: 'admin/company_management#create'

--- a/test/integration/company_review_workflow_test.rb
+++ b/test/integration/company_review_workflow_test.rb
@@ -1,0 +1,190 @@
+require "test_helper"
+
+# The Company tab as a working surface: reviews run without throwing the reviewer out
+# of the draft, findings appear beside the record, the default list is the publishing
+# workload rather than the whole index, and a batch review is capped and queued.
+class CompanyReviewWorkflowTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    sign_in admin_users(:one)
+    @company = companies(:one)
+    @company.update!(name: "Pactolane", main_url: "https://www.pactolane.com")
+    @company.update_columns(quality_status: nil, fingerprint: @company.calculated_fingerprint)
+  end
+
+  def agent_review_run(company: @company, status: "succeeded", run_type: "company_agent_review")
+    PipelineRun.create!(
+      name: "Agent company review: #{company.name}", run_type: run_type, status: status,
+      agent_name: "CompanyEvidenceAgent+CompanyVerifierAgent", records_processed: 1,
+      details: {
+        "company_id" => company.id,
+        "evidence" => [{ "title" => "Company website", "url" => "https://www.pactolane.com", "summary" => "Stored main url." }],
+        "description_draft" => { "proposed_description" => "Pactolane builds contract lifecycle management software for legal and procurement teams." },
+        "description_critic" => { "verdict" => "pass", "issues" => [], "suggested_revision" => "" },
+        "review_coordinator" => { "status" => "needs_more_evidence", "reasons" => ["The critic wanted more evidence."], "recommended_actions" => ["Check the website."] },
+        "proposed_corrections" => { "quality_score" => 90, "proposed_description" => "Pactolane builds contract lifecycle management software for legal and procurement teams." },
+        "risks" => []
+      }
+    )
+  end
+
+  def duplicate_review_run(company: @company)
+    PipelineRun.create!(
+      name: "Duplicate-domain review: #{company.name}", run_type: "duplicate_domain_review", status: "succeeded",
+      agent_name: "DuplicateReviewAgent", records_processed: 1,
+      details: {
+        "company_id" => company.id,
+        "duplicate_review" => {
+          "overall_recommendation" => "related_entities", "rationale" => "The records share a domain.",
+          "pair_reviews" => [{ "candidate_company_id" => companies(:two).id, "relationship" => "related", "confidence" => "low", "reasons" => ["Domains match."] }],
+          "unresolved_questions" => ["Product or company record?"]
+        }
+      }
+    )
+  end
+
+  # ---- items 1, 2, 4: findings live on the draft ---------------------------
+
+  test "the draft shows the latest agent review and duplicate review findings inline" do
+    agent_review_run
+    duplicate_review_run
+
+    get custom_admin_company_review_path(@company.id)
+
+    assert_response :success
+    assert_select "#agent-review h2", text: /Agent review/
+    assert_select "#duplicate-review h2", text: /Duplicate review/
+    assert_select "li", text: "The critic wanted more evidence."
+    assert_select "li", text: "Check the website."
+    assert_select "td", text: /Domains match\./
+    # The findings are actionable from here, not just readable.
+    assert_select "form[action=?]", apply_custom_admin_agent_review_path(PipelineRun.where(run_type: "company_agent_review").last)
+  end
+
+  test "the draft says so plainly when no review has been run" do
+    get custom_admin_company_review_path(@company.id)
+
+    assert_response :success
+    assert_select "#agent-review", text: /No agent review has been run/
+    assert_select "#duplicate-review", text: /No duplicate review has been run/
+  end
+
+  test "running either review returns to the draft rather than a separate page" do
+    CompanyAgentReviewService.stub(:call, agent_review_run) do
+      post custom_admin_company_agent_review_path(@company.id)
+    end
+    assert_redirected_to custom_admin_company_review_path(@company.id, anchor: "agent-review")
+
+    DuplicateDomainReviewService.stub(:call, duplicate_review_run) do
+      post custom_admin_company_duplicate_review_path(@company.id)
+    end
+    assert_redirected_to custom_admin_company_review_path(@company.id, anchor: "duplicate-review")
+  end
+
+  test "applying a correction from the draft comes back to the draft" do
+    run = agent_review_run
+
+    post apply_custom_admin_agent_review_path(run), params: { fields: ["quality_score"], return_to: "company" }
+
+    assert_redirected_to custom_admin_company_review_path(@company.id, anchor: "agent-review")
+    assert_equal 90, @company.reload.quality_score
+  end
+
+  test "the standalone review page offers a way back to the company it came from" do
+    run = agent_review_run
+
+    get custom_admin_agent_review_path(run)
+
+    assert_response :success
+    assert_select "a[href=?]", custom_admin_company_review_path(@company.id), text: /Back to company draft/
+  end
+
+  # ---- item 3: the Company tab is a working queue -------------------------
+
+  test "the default company list holds only records still needing a decision" do
+    needs_review = @company
+    verified = companies(:two)
+    verified.update_columns(quality_status: "verified")
+    rejected = Company.create!(
+      name: "Rejected Co", location: "Boston, MA", description: "A rejected legal technology record.",
+      category: categories(:one), target_client: target_clients(:one), business_models: [business_models(:one)]
+    )
+    rejected.update_columns(quality_status: "rejected")
+
+    get custom_admin_companies_path
+
+    assert_response :success
+    assert_includes response.body, "/admin/review/companies/#{needs_review.id}"
+    refute_includes response.body, "/admin/review/companies/#{verified.id}", "an approved record is not workload"
+    refute_includes response.body, "/admin/review/companies/#{rejected.id}", "a rejected record is not workload"
+  end
+
+  test "verified and rejected records stay reachable through their own filters" do
+    verified = companies(:two)
+    verified.update_columns(quality_status: "verified")
+
+    get custom_admin_companies_path(review_state: "verified")
+    assert_includes response.body, "/admin/review/companies/#{verified.id}"
+
+    get custom_admin_companies_path(review_state: "all")
+    assert_includes response.body, "/admin/review/companies/#{verified.id}"
+    assert_includes response.body, "/admin/review/companies/#{@company.id}"
+  end
+
+  test "deciding a record sends the reviewer back to the queue it has left" do
+    post custom_admin_company_mark_review_path(@company.id), params: { decision: "verified" }
+
+    assert_redirected_to custom_admin_companies_path
+    follow_redirect!
+    refute_includes response.body, "/admin/review/companies/#{@company.id}"
+  end
+
+  # ---- item 5: controlled batch review ------------------------------------
+
+  test "a batch review queues one job per selected company without publishing anything" do
+    other = companies(:two)
+
+    assert_enqueued_jobs 2, only: CompanyAgentReviewJob do
+      post batch_agent_review_custom_admin_companies_path, params: { company_ids: [@company.id, other.id] }
+    end
+
+    assert_redirected_to custom_admin_companies_path
+    assert_match(/Queued agent reviews for 2 companies/, flash[:notice])
+    refute @company.reload.visible? && @company.quality_status == "verified", "a batch review never decides anything"
+  end
+
+  test "a batch larger than the cap is refused rather than partially run" do
+    ids = (1..11).map { |i| i }
+
+    assert_no_enqueued_jobs only: CompanyAgentReviewJob do
+      post batch_agent_review_custom_admin_companies_path, params: { company_ids: ids }
+    end
+    assert_match(/at most 10/, flash[:alert])
+  end
+
+  test "an empty selection is refused" do
+    assert_no_enqueued_jobs only: CompanyAgentReviewJob do
+      post batch_agent_review_custom_admin_companies_path, params: { company_ids: [] }
+    end
+    assert_match(/Select at least one company/, flash[:alert])
+  end
+
+  test "a company already mid-review is skipped rather than queued twice" do
+    agent_review_run(status: "running")
+
+    assert_enqueued_jobs 0, only: CompanyAgentReviewJob do
+      post batch_agent_review_custom_admin_companies_path, params: { company_ids: [@company.id] }
+    end
+    assert_match(/already had a review in progress/, flash[:notice])
+  end
+
+  test "the company list offers the batch control" do
+    get custom_admin_companies_path
+
+    assert_response :success
+    assert_select "form[action=?]", batch_agent_review_custom_admin_companies_path
+    assert_select "input[name=?]", "company_ids[]"
+    assert_select "input[data-batch-select-all]"
+  end
+end

--- a/test/integration/custom_admin_test.rb
+++ b/test/integration/custom_admin_test.rb
@@ -149,7 +149,7 @@ class CustomAdminTest < ActionDispatch::IntegrationTest
 
     post custom_admin_company_mark_review_path(company.id), params: { decision: "verified" }
 
-    assert_redirected_to custom_admin_company_review_path(company.id)
+    assert_redirected_to custom_admin_companies_path
     company.reload
     assert_equal "verified", company.quality_status
     assert_equal "human_confirmed", company.verification_verdict
@@ -186,7 +186,8 @@ class CustomAdminTest < ActionDispatch::IntegrationTest
     end
 
     run = PipelineRun.order(:created_at).last
-    assert_redirected_to custom_admin_agent_review_path(run)
+    # The reviewer stays on the company draft; the findings render there.
+    assert_redirected_to custom_admin_company_review_path(company.id, anchor: "agent-review")
     assert_equal "company_agent_review", run.run_type
     assert_equal "agent_proposal_no_public_writes", run.details["mode"]
     assert_equal company.id, run.details["company_id"]
@@ -277,18 +278,18 @@ class CustomAdminTest < ActionDispatch::IntegrationTest
     get custom_admin_agent_review_path(run)
     assert_response :success
     assert_select "h1", "Agent review sample"
-    assert_select "h2", "Description Draft"
+    assert_select "h2", "Description"
     assert_select "span", "Review only"
     assert_select ".alert-warning", text: /does not clear the publication gate/
     assert_select "p", text: "ExampleCo provides legal technology software for law firms."
-    assert_select "h2", "Review Coordinator"
+    assert_select "h2", "What the review found"
     assert_select "li", "Critic requires revision."
-    assert_select "h2", "Description Critic"
+    assert_select "h2", "Description"
     assert_select "li", "Needs stronger evidence."
-    assert_select "h2", "Duplicate Review"
+    assert_select "h2", "Duplicate review"
     assert_select "td", "Related"
-    assert_select "h2", "Evidence"
-    assert_select "h2", "Proposed Corrections"
+    assert_select "h2", "Evidence used"
+    assert_select "h2", "Apply corrections"
     assert_equal companies(:one).description, companies(:one).reload.description
   end
 
@@ -333,7 +334,7 @@ class CustomAdminTest < ActionDispatch::IntegrationTest
     get custom_admin_agent_review_path(run)
     assert_response :success
     assert_select "span.badge", "Ready to apply"
-    assert_select "label[for='field_description']", text: /Description/
+    assert_select "label", text: /Description/
 
     post apply_custom_admin_agent_review_path(run), params: { fields: ["description"] }
 
@@ -615,7 +616,7 @@ class CustomAdminTest < ActionDispatch::IntegrationTest
     assert_select "h1", "Review"
     assert_select ".admin-section-tabs", false
     assert_select ".admin-proposal-batch-actions.d-none"
-    assert_select "input[data-proposal-select-all]"
+    assert_select "input[data-batch-select-all]"
     assert_select "button", "Re-enrich selected"
     assert_select "button", "Mark needs revision"
     assert_select "button", "Publish selected"


### PR DESCRIPTION
Hafez's five Company-tab items. Four are the same underlying problem — the reviewer kept being thrown out of the record they were working on — so they're fixed together.

## Findings now render where the reviewer already is (items 1, 2, 4)

Running either review redirected to a separate agent-review page, so the reviewer lost the draft they were mid-way through. Results now sit on the draft itself, in the order the work follows:

**Company information → Agent review → Duplicate review → Reviewer decision**

- Running either review reloads the draft at the section it just filled in
- Applying a correction from there returns to the same place
- Verified against the rendered page: section order is exactly as above

The apply rules and packet shape moved out of the controller into `AgentReviewPacket`, so findings and the apply control render identically in both places rather than being reimplemented per view. The standalone packet page survives — it's linked from Activity and worth keeping — and now carries a **Back to company draft** action returning to the record that started the review (item 2.4/2.5).

Reviewer-facing labels lost their internal accent: *Review Coordinator* → **What the review found**, with *Why* / *Where the agents disagreed* / *Suggested next steps* replacing reasons/disagreements/recommended_actions.

## The Company tab defaults to the publishing workload (item 3)

It listed all 5,814 records, so approved and rejected entries sat among those awaiting a decision. The default is now records that still need one. Verified, rejected and awaiting-contributor stay one filter click away, and a new **All records** option restores the full list for browsing. Verifying or rejecting returns the reviewer to the queue — which is where the record has just stopped being work.

## Batch agent review, capped and queued (item 5)

Up to ten drafts selected and reviewed in one action. Each runs as its own job so one failure can't take the others down, and a company with a review already pending or running is skipped rather than queued twice. Findings only: nothing is approved, published or rejected, and every record still goes through the same human decision.

## One implementation note worth your attention

The obvious way to add row selection is to wrap the table in the batch form. **That silently broke the per-row Delete** — the company rows already contain `button_to` forms, and HTML forbids nesting forms, so the parser drops the inner one. The existing test caught it. The batch form now stands alone and the checkboxes join it through the HTML5 `form` attribute; verified with a real HTML parse that the page has zero parser-visible nested forms and Delete is intact.

While there, the selection script — previously a copy living inside the proposal queue — became one shared partial that resolves checkboxes whether they're nested or form-associated. One implementation instead of two.

## Testing

`bin/rails test` — **634 runs, 2941 assertions, 0 failures, 0 errors**.

New `company_review_workflow_test` (13 tests) covers inline findings, the no-review empty state, both redirects, apply-and-return, the default queue contents, the filters that still reach history, and all four batch guards (cap, empty, in-flight skip, control present). Six existing assertions in `custom_admin_test` encoded the old redirect targets and card headings and were updated deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)