### PR TITLE
Let an agent repair a live record; stop enrichment overwriting reviewed text

### DIFF
--- a/app/agents/description_verification_agent.rb
+++ b/app/agents/description_verification_agent.rb
@@ -6,7 +6,6 @@
 # a search tool would only let it produce URLs the service then throws away.
 class DescriptionVerificationAgent < RubyLLM::Agent
   model "gpt-5.5"
-  instructions
   temperature 0.1
 
   DEFAULT_TIMEOUT_SECONDS = 90

--- a/app/controllers/admin/company_proposals_controller.rb
+++ b/app/controllers/admin/company_proposals_controller.rb
@@ -35,9 +35,11 @@ module Admin
 
     def enrich
       load_proposal
-      CompanyProposalEnrichmentService.call(proposal: @company_proposal, admin_user: current_admin_user)
+      CompanyProposalEnrichmentService.call(proposal: @company_proposal, admin_user: current_admin_user, force: true)
 
       redirect_to custom_admin_company_proposal_path(@company_proposal), notice: "Proposal enriched for review. No company records were changed."
+    rescue CompanyProposalEnrichmentService::Locked => e
+      redirect_to custom_admin_company_proposal_path(@company_proposal), alert: e.message
     end
 
     def approve

--- a/app/jobs/enrich_proposal_job.rb
+++ b/app/jobs/enrich_proposal_job.rb
@@ -11,6 +11,12 @@ class EnrichProposalJob < ApplicationJob
 
     admin_user = AdminUser.find_by(id: admin_user_id) || Mcp::CuratorActor.admin_user!
     CompanyProposalEnrichmentService.call(proposal: proposal, admin_user: admin_user)
+  rescue CompanyProposalEnrichmentService::Locked => e
+    # Not a failure: the record is past the point where enrichment may change it.
+    Rails.logger.info("[EnrichProposalJob] #{e.message}")
+    proposal&.update_columns(agent_details: (proposal.agent_details || {}).merge(
+      "enrichment_skipped" => { "reason" => e.message, "at" => Time.current.utc.iso8601 }
+    ))
   rescue StandardError => e
     Rails.logger.debug("[EnrichProposalJob] enrichment failed for proposal #{proposal_id}: #{e.message}")
     proposal&.update_columns(

--- a/app/mcp/tools/duplicate_check_tool.rb
+++ b/app/mcp/tools/duplicate_check_tool.rb
@@ -3,7 +3,7 @@ module Mcp
     class DuplicateCheckTool < BaseTool
       tool_name "duplicate_check"
       title "Duplicate check"
-      description "Check whether a company name/URL already exists in the visible index (name and canonical-domain matching)."
+      description "Check whether a company name/URL already exists in the index, published or as an unpublished draft (name and canonical-domain matching). Each match reports `visible`, so a hidden draft from an earlier approval is distinguishable from a live entry — approving over one of those is what creates duplicates."
       annotations(read_only_hint: true, destructive_hint: false, idempotent_hint: true, title: "Duplicate check")
       input_schema(
         properties: {

--- a/app/mcp/tools/update_company_field_tool.rb
+++ b/app/mcp/tools/update_company_field_tool.rb
@@ -1,16 +1,22 @@
 module Mcp
   module Tools
-    # In-place edit of a small allowlist of SAFE FACTUAL fields on an existing
-    # (typically published) company, so a backfilled value (e.g. a sourced founding
-    # year) lands on the live profile in a single call — without unpublishing or a
-    # separate human-approved suggestion. Editorial changes (e.g. description) must
-    # still go through propose_company_update.
+    # In-place edit of a small allowlist of fields on an existing (typically published)
+    # company, so a correction lands on the live profile in a single call.
+    #
+    # description was excluded here until it became the thing most often needing repair:
+    # an enrichment that overwrote a submitter's text left no tool able to put it back,
+    # and the fix required engineering every time. It is writable now, but only through
+    # the same deterministic gate every published description passes, with a mandatory
+    # reason recorded, and it sets a lock so the next enrichment cannot silently undo the
+    # repair — which is exactly how the SpecterAI restore was lost in August.
     class UpdateCompanyFieldTool < BaseTool
       FACT_FIELDS = %w[founded_date location founders status].freeze
+      TEXT_FIELDS = %w[description main_url linkedin_url crunchbase_url].freeze
+      WRITABLE_FIELDS = (FACT_FIELDS + TEXT_FIELDS).freeze
 
       tool_name "update_company_field"
       title "Update company factual field"
-      description "Edit safe factual fields (#{FACT_FIELDS.join(', ')}) directly on an existing/published company so a backfilled value lands on the live profile in one call. founded_date must be a plausible 4-digit year and REQUIRES a source_url (cite-only — never guess a year). Use propose_company_update for editorial changes or anything outside this allowlist."
+      description "Edit an existing/published company in place: #{WRITABLE_FIELDS.join(', ')}. founded_date must be a plausible 4-digit year and REQUIRES a source_url (cite-only — never guess a year). Writing description or a url REQUIRES a `reason` (e.g. 'restoring the submitter's original text after an enrichment overwrote it'); a description must clear the same publication gate as any published text, and writing one locks the record against further automated description changes until a human unlocks it. Use propose_company_update for anything outside this allowlist."
       annotations(read_only_hint: false, destructive_hint: false, idempotent_hint: true, title: "Update company factual field")
       input_schema(
         properties: {
@@ -22,21 +28,47 @@ module Mcp
               founded_date: { type: "string", description: "4-digit founding year (requires source_url)." },
               location: { type: "string" },
               founders: { type: "string" },
-              status: { type: "string", description: "Lifecycle status, e.g. active, acquired, defunct." }
+              status: { type: "string", description: "Lifecycle status, e.g. active, acquired, defunct." },
+              description: { type: "string", description: "Public description. Must clear the publication gate; requires reason." },
+              main_url: { type: "string", description: "Primary website. Requires reason." },
+              linkedin_url: { type: "string", description: "LinkedIn company URL. Requires reason." },
+              crunchbase_url: { type: "string", description: "Crunchbase URL. Requires reason." }
             },
             additionalProperties: false
           },
-          source_url: { type: "string", description: "Citation URL supporting the value; required when setting founded_date." }
+          source_url: { type: "string", description: "Citation URL supporting the value; required when setting founded_date." },
+          reason: { type: "string", description: "Why this edit is being made. Required for description and url fields, and recorded on the company." },
+          lock_description: { type: "boolean", description: "Default true when writing a description: stops later automated enrichment overwriting it. Pass false only when the record should stay open to enrichment." }
         },
         required: %w[slug fields]
       )
 
-      def self.call(server_context:, slug:, fields:, source_url: nil)
+      def self.call(server_context:, slug:, fields:, source_url: nil, reason: nil, lock_description: nil)
         company = find_company(slug)
         return not_found("Company '#{slug}' not found") unless company
 
-        applied = (fields || {}).transform_keys(&:to_s).slice(*FACT_FIELDS).compact
-        return not_found("No factual fields provided. Allowed: #{FACT_FIELDS.join(', ')}") if applied.empty?
+        applied = (fields || {}).transform_keys(&:to_s).slice(*WRITABLE_FIELDS).compact
+        return not_found("No writable fields provided. Allowed: #{WRITABLE_FIELDS.join(', ')}") if applied.empty?
+
+        # An edit to public text has to say why. Without it there is no way for the next
+        # reader to tell a considered restore from an accident.
+        text_edits = applied.slice(*TEXT_FIELDS)
+        if text_edits.any? && reason.to_s.strip.blank?
+          return error_response("result" => "blocked", "retryable" => false, "error" => "Editing #{text_edits.keys.to_sentence} requires a `reason` explaining the change.")
+        end
+
+        if applied["description"].present?
+          verdict = CompanyProposalEnrichmentService.description_critic_for(applied["description"])
+          unless verdict["verdict"] == "pass"
+            issues = Array(verdict["issues"]).to_sentence.presence
+            return error_response("result" => "blocked", "retryable" => false, "error" => "That description does not clear the publication gate#{" (#{issues})" if issues}.")
+          end
+        end
+
+        %w[main_url linkedin_url crunchbase_url].each do |url_field|
+          next if applied[url_field].blank?
+          return error_response("result" => "blocked", "retryable" => false, "error" => "#{url_field} must be an http(s) URL.") unless valid_http_url?(applied[url_field])
+        end
 
         if applied["founded_date"].present?
           year = applied["founded_date"].to_s.strip
@@ -44,12 +76,16 @@ module Mcp
           return error_response("result" => "blocked", "retryable" => false, "error" => "founded_date requires a source_url citation (cite-only — never guess a founding year).") unless valid_http_url?(source_url)
         end
 
+        previous = applied.keys.index_with { |field| company.public_send(field) }
+
         other_fields = applied.except("founded_date")
         other_fields.each { |field, value| company.public_send("#{field}=", value) }
+        company.canonical_domain = company.canonical_main_domain if applied.key?("main_url")
+        record_edit!(company, applied: applied, previous: previous, reason: reason, lock: lock_description)
         company.save! if other_fields.any?
         company.founded_date_from_source!(year: applied["founded_date"], source_url: source_url) if applied["founded_date"].present?
 
-        audit!(action: "update_company_field", summary: "Updated #{applied.keys.join(', ')} on #{company.name}", records_processed: 1, details: { "company_id" => company.id, "applied" => applied, "source_url" => source_url })
+        audit!(action: "update_company_field", summary: "Updated #{applied.keys.join(', ')} on #{company.name}", records_processed: 1, details: { "company_id" => company.id, "applied" => applied, "previous" => previous, "reason" => reason, "source_url" => source_url })
 
         json_response(
           "result" => "updated",
@@ -64,6 +100,28 @@ module Mcp
       rescue StandardError => e
         Rails.logger.debug("[UpdateCompanyFieldTool] transient failure for #{slug}: #{e.class}: #{e.message}")
         error_response("result" => "error", "retryable" => true, "error" => "Transient failure (#{e.class}); safe to retry: #{e.message}")
+      end
+
+      # Provenance for an in-place edit to a live entry, and the lock that stops the next
+      # automated pass undoing it. Appended, never replaced, so a record's repair history
+      # stays readable.
+      def self.record_edit!(company, applied:, previous:, reason:, lock:)
+        review = company.quality_review.is_a?(Hash) ? company.quality_review.deep_dup : {}
+        review["field_edits"] = Array(review["field_edits"]) + [{
+          "at" => Time.current.utc.iso8601,
+          "via" => "update_company_field",
+          "reason" => reason.to_s.strip.presence,
+          "changes" => applied.keys.index_with { |field| { "from" => previous[field], "to" => applied[field] } }
+        }]
+
+        if applied.key?("description")
+          locked = lock.nil? ? true : ActiveModel::Type::Boolean.new.cast(lock)
+          review["description_locked"] = locked
+          review["description_locked_at"] = locked ? Time.current.utc.iso8601 : nil
+          review["description_locked_reason"] = locked ? reason.to_s.strip.presence : nil
+        end
+
+        company.quality_review = review
       end
 
       def self.plausible_year?(value)

--- a/app/services/atlas_candidate_normalizer_service.rb
+++ b/app/services/atlas_candidate_normalizer_service.rb
@@ -50,16 +50,24 @@ class AtlasCandidateNormalizerService
     row["Organization Name"].to_s.strip
   end
 
+  # Everything that could collide: published entries and unpublished drafts alike.
+  # A rejected record is genuinely out of the way and stays excluded.
+  def matchable
+    Company.where("companies.quality_status IS DISTINCT FROM ?", "rejected")
+  end
+
   def name_match_payloads(normalized_name)
     return [] if normalized_name.blank?
 
-    Company.where.not(name: [nil, ""]).select { |company| company.visible? && company.normalized_name == normalized_name }.first(10).map { |company| company_payload(company) }
+    # Hidden drafts count. Excluding them is what let a second approval mint a duplicate
+    # of a company the first approval had already created but not yet published.
+    matchable.where.not(name: [nil, ""]).select { |company| company.normalized_name == normalized_name }.first(10).map { |company| company_payload(company) }
   end
 
   def domain_match_payloads(canonical_domain)
     return [] if canonical_domain.blank?
 
-    Company.where.not(main_url: [nil, ""]).select { |company| company.visible? && (company.canonical_domain.presence || company.canonical_main_domain) == canonical_domain }.first(10).map { |company| company_payload(company) }
+    matchable.where.not(main_url: [nil, ""]).select { |company| (company.canonical_domain.presence || company.canonical_main_domain) == canonical_domain }.first(10).map { |company| company_payload(company) }
   end
 
   def company_payload(company)

--- a/app/services/company_proposal_approval_service.rb
+++ b/app/services/company_proposal_approval_service.rb
@@ -133,7 +133,7 @@ class CompanyProposalApprovalService
   def ensure_description!
     return if proposal.final_changes["description"].present?
 
-    CompanyProposalEnrichmentService.call(proposal: proposal, admin_user: admin_user)
+    CompanyProposalEnrichmentService.call(proposal: proposal, admin_user: admin_user, force: true)
     proposal.reload
   end
 end

--- a/app/services/company_proposal_batch_service.rb
+++ b/app/services/company_proposal_batch_service.rb
@@ -29,7 +29,7 @@ class CompanyProposalBatchService
   def perform(proposal)
     case action
     when "reenrich"
-      CompanyProposalEnrichmentService.call(proposal: proposal, admin_user: admin_user)
+      CompanyProposalEnrichmentService.call(proposal: proposal, admin_user: admin_user, force: true)
       { "proposal_id" => proposal.id, "status" => "reenriched" }
     when "mark_needs_revision"
       proposal.update!(status: "needs_revision", admin_user: admin_user, reviewed_at: Time.current)

--- a/app/services/company_proposal_enrichment_service.rb
+++ b/app/services/company_proposal_enrichment_service.rb
@@ -157,12 +157,37 @@ class CompanyProposalEnrichmentService
     a == b || a.end_with?(".#{b}") || b.end_with?(".#{a}")
   end
 
-  def initialize(proposal:, admin_user:)
+  def initialize(proposal:, admin_user:, force: false)
     @proposal = proposal
     @admin_user = admin_user
+    @force = ActiveModel::Type::Boolean.new.cast(force)
+  end
+
+  # Refused when the record is no longer enrichment's to change. Three approvals were
+  # lost to this: a background enrich rewrote the description 31 seconds before the
+  # approval landed, so the text that went live was not the text the reviewer read.
+  # Once a human has looked at a record, or it has been approved, or its description was
+  # deliberately repaired, enrichment stops touching it unless asked explicitly.
+  class Locked < StandardError; end
+
+  def locked_reason
+    return "it has already been approved (#{proposal.status})" if proposal.status.in?(%w[approved_to_draft published])
+    return "a human reviewed it at #{proposal.reviewed_at.utc.iso8601}" if proposal.reviewed_at.present?
+    return "its description is locked against automated changes" if description_locked?
+    return "the record was returned to its contributor" if proposal.company&.quality_status == CompanyReviewMarkService::RETURNED_STATUS
+
+    nil
+  end
+
+  def description_locked?
+    proposal.company&.quality_review.is_a?(Hash) && proposal.company.quality_review["description_locked"] == true
   end
 
   def call
+    if !force && (reason = locked_reason)
+      raise Locked, "Enrichment skipped for proposal #{proposal.id}: #{reason}. Pass force to override."
+    end
+
     load_enrichment_inputs
     final_changes = proposal.final_changes.merge(enriched_changes).merge(taxonomy_changes)
     agent_payload = agent_details(final_changes)
@@ -185,7 +210,7 @@ class CompanyProposalEnrichmentService
 
   private
 
-  attr_reader :proposal, :admin_user
+  attr_reader :proposal, :admin_user, :force
 
   # Gather description + founded year + taxonomy. When the single-call path is enabled
   # (default in production), ONE OpenAI Responses web-search call returns all of it and

--- a/app/services/company_review_mark_service.rb
+++ b/app/services/company_review_mark_service.rb
@@ -76,7 +76,9 @@ class CompanyReviewMarkService
       verification_verdict: "awaiting_contributor_update",
       # Taken off the public site while it is known to be incomplete, but never deleted.
       visible: false,
-      human_reviewed_at: Time.current,
+      # human_reviewed_at is deliberately left alone: it records who reviewed the record,
+      # and handing it back to its contributor is not that. Overwriting it erased an
+      # approval that had been made five minutes earlier.
       quality_reviewed_at: Time.current,
       # History is appended, never replaced, so earlier rounds stay readable.
       quality_review: append_history(request)

--- a/app/services/description_verification_service.rb
+++ b/app/services/description_verification_service.rb
@@ -54,7 +54,7 @@ class DescriptionVerificationService
     validate(parsed)
   rescue StandardError => e
     Rails.logger.debug("[DescriptionVerificationService] failed for #{company_name}: #{e.class}: #{e.message}")
-    manual_review("The verification step failed to complete (#{e.class.name}). Review this record by hand.")
+    skipped("The verification step could not run (#{e.class.name}), so this description has not been checked. This is a fault on our side, not a finding about the record.")
   end
 
   # What the publish gate needs to know, without it having to understand the payload.

--- a/test/services/maintenance_tooling_test.rb
+++ b/test/services/maintenance_tooling_test.rb
@@ -1,0 +1,127 @@
+require "test_helper"
+require "minitest/mock"
+
+# The five failures behind tonight's stalled approvals, each covered so the same wall
+# cannot come back silently.
+class MaintenanceToolingTest < ActiveSupport::TestCase
+  GOOD = "Veronto builds an access-request and trade-secret workflow platform for law firms and in-house legal teams, hosted in the EU.".freeze
+
+  setup do
+    @admin = admin_users(:one)
+    @company = companies(:one)
+    @company.update!(name: "Veronto", main_url: "https://veronto.example", description: "An enrichment overwrote the original text.")
+    @company.update_columns(quality_status: nil, quality_review: nil, fingerprint: @company.calculated_fingerprint)
+    @context = { admin_user: @admin }
+  end
+
+  def call_tool(tool, **args)
+    JSON.parse(tool.call(server_context: @context, **args).to_h[:content].first[:text])
+  end
+
+  def proposal(status: "pending", reviewed_at: nil, company: nil)
+    changes = { "name" => "Veronto", "main_url" => "https://veronto.example", "description" => GOOD }
+    CompanyProposal.create!(
+      status: status, proposal_type: "user_contribution", source: "user_contribution",
+      source_identifier: SecureRandom.uuid, source_payload: {},
+      proposed_changes: changes, final_changes: changes, duplicate_signals: {},
+      reviewed_at: reviewed_at, company: company
+    )
+  end
+
+  # ---- 1. a description is repairable without engineering -----------------
+
+  test "a company description can be restored, with a reason and its previous value kept" do
+    result = call_tool(Mcp::Tools::UpdateCompanyFieldTool, slug: @company.slug,
+                       fields: { "description" => GOOD },
+                       reason: "Restoring the submitter's original text after an enrichment overwrote it.")
+
+    assert_equal GOOD, @company.reload.description
+    edit = @company.quality_review["field_edits"].last
+    assert_equal "Restoring the submitter's original text after an enrichment overwrote it.", edit["reason"]
+    assert_equal "An enrichment overwrote the original text.", edit["changes"]["description"]["from"]
+    refute_equal "blocked", result["result"]
+  end
+
+  test "restoring a description requires a reason and refuses text that fails the gate" do
+    no_reason = call_tool(Mcp::Tools::UpdateCompanyFieldTool, slug: @company.slug, fields: { "description" => GOOD })
+    assert_equal "blocked", no_reason["result"]
+    assert_match(/requires a `reason`/, no_reason["error"])
+
+    promotional = call_tool(Mcp::Tools::UpdateCompanyFieldTool, slug: @company.slug,
+                            fields: { "description" => "Veronto is the leading best-in-class legal platform." }, reason: "test")
+    assert_equal "blocked", promotional["result"]
+    assert_match(/publication gate/, promotional["error"])
+    refute_equal GOOD, @company.reload.description
+  end
+
+  test "a broken website can be corrected in place" do
+    call_tool(Mcp::Tools::UpdateCompanyFieldTool, slug: @company.slug,
+              fields: { "main_url" => "https://veronto.de" }, reason: "Site moved; the old domain 404s.")
+
+    assert_equal "https://veronto.de", @company.reload.main_url
+    assert_equal "veronto.de", @company.canonical_domain, "the dedup key follows the url"
+  end
+
+  # ---- 2. a repair is not undone by the next enrichment -------------------
+
+  test "writing a description locks the record against automated description changes" do
+    call_tool(Mcp::Tools::UpdateCompanyFieldTool, slug: @company.slug, fields: { "description" => GOOD }, reason: "Restore.")
+    assert @company.reload.quality_review["description_locked"]
+
+    locked = proposal(company: @company)
+    error = assert_raises(CompanyProposalEnrichmentService::Locked) do
+      CompanyProposalEnrichmentService.call(proposal: locked, admin_user: @admin)
+    end
+    assert_match(/description is locked/, error.message)
+  end
+
+  # ---- 3. enrichment cannot rewrite what a reviewer already read ----------
+
+  test "enrichment refuses a record a human has reviewed or approved" do
+    reviewed = proposal(reviewed_at: 1.minute.ago)
+    assert_raises(CompanyProposalEnrichmentService::Locked) do
+      CompanyProposalEnrichmentService.call(proposal: reviewed, admin_user: @admin)
+    end
+
+    approved = proposal(status: "approved_to_draft")
+    error = assert_raises(CompanyProposalEnrichmentService::Locked) do
+      CompanyProposalEnrichmentService.call(proposal: approved, admin_user: @admin)
+    end
+    assert_match(/already been approved/, error.message)
+  end
+
+  test "an explicit request still enriches, and the job records a skip rather than failing" do
+    reviewed = proposal(reviewed_at: 1.minute.ago)
+    assert_nothing_raised { CompanyProposalEnrichmentService.call(proposal: reviewed, admin_user: @admin, force: true) }
+
+    skipped = proposal(reviewed_at: 1.minute.ago)
+    EnrichProposalJob.perform_now(skipped.id, @admin.id)
+    assert skipped.reload.agent_details["enrichment_skipped"].present?, "a skip is recorded, not raised"
+  end
+
+  # ---- 4. an approval record is not overwritten by a later action ---------
+
+  test "returning a record to its contributor preserves who reviewed it" do
+    approved_at = 2.hours.ago.change(usec: 0)
+    @company.update_columns(human_reviewed_at: approved_at, quality_status: "needs_review")
+
+    CompanyReviewMarkService.call(company: @company, decision: "return_to_contributor",
+                                  admin_user: @admin, instructions: "Please supply a working URL.")
+
+    assert_equal approved_at.to_i, @company.reload.human_reviewed_at.to_i, "the approval timestamp survives"
+    assert_equal "awaiting_contributor", @company.review_state
+  end
+
+  # ---- 5. duplicate checks see hidden drafts -----------------------------
+
+  test "duplicate_check finds an unpublished draft so a second approval cannot duplicate it" do
+    @company.update_columns(visible: false)
+
+    result = call_tool(Mcp::Tools::DuplicateCheckTool, name: "Veronto", url: "https://veronto.example")
+
+    assert_equal "existing_or_possible_duplicate", result["status"]
+    match = (result["name_matches"] + result["domain_matches"]).first
+    assert_equal @company.id, match["id"]
+    assert_equal false, match["visible"], "and the caller can tell it is only a draft"
+  end
+end


### PR DESCRIPTION
Verified against production before changing anything — the report came from an agent and two of its claims contradicted what I believed was in the code. Both were right.

## The blocking fault was mine, shipped in v538

`DescriptionVerificationAgent` declared `instructions` with no prompt file under `app/prompts/`, so **every call raised `RubyLLM::PromptNotFoundError`**. The service caught it, returned `MANUAL_REVIEW`, and `MANUAL_REVIEW` blocks publication.

So every enrichment since v538 produced an unpublishable record. Proposals 4137, 4138 and 4139 all carry that same error — this is the "seventh approval in a row that hasn't gone public".

Two fixes: the declaration is gone, and **a crash in our own code now returns `SKIPPED`** rather than a verdict. A fault on our side is not a finding about the record and has no business holding a queue shut. I had already made the *unavailable* case non-blocking and left the *crash* case blocking, which is exactly the distinction that mattered.

## Five tooling gaps

Each one forced a human to do something an agent should be able to do, or let automation undo a human.

**1. A live description wasn't writable by any tool.** `update_company_field` now writes `description`, `main_url`, `linkedin_url`, `crunchbase_url`. Public text requires a `reason`; a description must clear the same gate as any published description; the previous value and reason are appended to the record's edit history; `main_url` carries the canonical domain with it so the dedup key doesn't go stale.

**2. A restore was destroyed by the next enrichment** — how the SpecterAI restore was lost in August. Writing a description now **locks** the record against automated description changes until a human unlocks it.

**3. Enrichment raced approval.** Verified timings: the enrich landed **31s, 34s and 3min** before the approval on the three records, so the published text was not the text the reviewer read. Enrichment now refuses a proposal that is approved, human-reviewed, description-locked, or returned to its contributor. Explicit requests still override; background jobs record the skip instead of failing.

**4. Contributor-return erased the approval record.** It was setting `human_reviewed_at`, overwriting an approval made five minutes earlier — why Pieter's decision no longer showed on UpGrowth 4137. It keeps its own timestamps and leaves the human review record alone.

**5. Duplicate checks ignored hidden records**, so re-approving a repaired record would duplicate the draft the first approval already created. Matching now covers unpublished drafts and reports `visible` per match.

## Testing

`bin/rails test` under **CI's own environment values** (not a local pass — that's how the last CI failure got through): **666 runs, 3056 assertions, 0 failures**.

New `maintenance_tooling_test` covers all five: restore with reason and history, the two refusal paths, url repair carrying the domain, the enrichment lock, the reviewed/approved refusals, force-override, the job's skip record, the preserved approval timestamp, and duplicate_check finding a hidden draft.

## Not included

The three records still need their original text put back. That's a data operation on live records, and now that the tool exists an agent can do it — but I haven't touched production data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)