### PR TITLE
Require a verified description for autonomous publication; guard the pending window

### DIFF
--- a/app/controllers/admin/company_proposals_controller.rb
+++ b/app/controllers/admin/company_proposals_controller.rb
@@ -51,7 +51,7 @@ module Admin
         SlackNotifier.contribution_decision(@company_proposal, decision: "approved", admin_user: current_admin_user, note: "Applied update to #{company.name}.")
         redirect_to custom_admin_company_review_path(company.id), notice: "Update applied to #{company.name}."
       else
-        company = CompanyProposalApprovalService.call(proposal: @company_proposal, admin_user: current_admin_user, duplicate_override: params[:duplicate_override] == "1", publish: publish)
+        company = CompanyProposalApprovalService.call(proposal: @company_proposal, admin_user: current_admin_user, duplicate_override: params[:duplicate_override] == "1", publish: publish, reviewed_description_digest: params[:reviewed_description_digest])
         SlackNotifier.contribution_decision(@company_proposal, decision: "approved", admin_user: current_admin_user, note: publish ? "Published #{company.name}." : "Draft created for #{company.name}.")
         notice = publish ? "#{company.name} was approved and published." : "Invisible company draft created for #{company.name}. Review once more before publication."
         redirect_to custom_admin_company_review_path(company.id), notice: notice

--- a/app/mcp/tools/update_company_field_tool.rb
+++ b/app/mcp/tools/update_company_field_tool.rb
@@ -12,7 +12,10 @@ module Mcp
     class UpdateCompanyFieldTool < BaseTool
       FACT_FIELDS = %w[founded_date location founders status].freeze
       TEXT_FIELDS = %w[description main_url linkedin_url crunchbase_url].freeze
-      WRITABLE_FIELDS = (FACT_FIELDS + TEXT_FIELDS).freeze
+      # Taxonomy an enrichment can get wrong and nothing could then put right: tags were
+      # unreachable, and a wrongly-set secondary category could not be cleared at all.
+      TAXONOMY_FIELDS = %w[all_tags secondary_category_id].freeze
+      WRITABLE_FIELDS = (FACT_FIELDS + TEXT_FIELDS + TAXONOMY_FIELDS).freeze
 
       tool_name "update_company_field"
       title "Update company factual field"
@@ -32,7 +35,9 @@ module Mcp
               description: { type: "string", description: "Public description. Must clear the publication gate; requires reason." },
               main_url: { type: "string", description: "Primary website. Requires reason." },
               linkedin_url: { type: "string", description: "LinkedIn company URL. Requires reason." },
-              crunchbase_url: { type: "string", description: "Crunchbase URL. Requires reason." }
+              crunchbase_url: { type: "string", description: "Crunchbase URL. Requires reason." },
+              all_tags: { type: "string", description: "Comma-separated tag list, replacing the current tags. Requires reason." },
+              secondary_category_id: { type: %w[integer string null], description: "Secondary category id, or null/empty to clear it. Requires reason." }
             },
             additionalProperties: false
           },
@@ -47,12 +52,16 @@ module Mcp
         company = find_company(slug)
         return not_found("Company '#{slug}' not found") unless company
 
-        applied = (fields || {}).transform_keys(&:to_s).slice(*WRITABLE_FIELDS).compact
+        raw = (fields || {}).transform_keys(&:to_s).slice(*WRITABLE_FIELDS)
+        # An explicit null clears secondary_category_id, so it must survive `compact`.
+        clearing = raw.key?("secondary_category_id") && raw["secondary_category_id"].blank?
+        applied = raw.compact
+        applied["secondary_category_id"] = nil if clearing
         return not_found("No writable fields provided. Allowed: #{WRITABLE_FIELDS.join(', ')}") if applied.empty?
 
         # An edit to public text has to say why. Without it there is no way for the next
         # reader to tell a considered restore from an accident.
-        text_edits = applied.slice(*TEXT_FIELDS)
+        text_edits = applied.slice(*TEXT_FIELDS, *TAXONOMY_FIELDS)
         if text_edits.any? && reason.to_s.strip.blank?
           return error_response("result" => "blocked", "retryable" => false, "error" => "Editing #{text_edits.keys.to_sentence} requires a `reason` explaining the change.")
         end
@@ -80,6 +89,7 @@ module Mcp
 
         other_fields = applied.except("founded_date")
         other_fields.each { |field, value| company.public_send("#{field}=", value) }
+        company.all_tags = applied["all_tags"] if applied.key?("all_tags")
         company.canonical_domain = company.canonical_main_domain if applied.key?("main_url")
         record_edit!(company, applied: applied, previous: previous, reason: reason, lock: lock_description)
         company.save! if other_fields.any?

--- a/app/services/company_import_worker_service.rb
+++ b/app/services/company_import_worker_service.rb
@@ -95,7 +95,9 @@ class CompanyImportWorkerService
 
   def publish_if_ready(result, quality)
     return result unless result["action"].in?(%w[auto_drafted already_drafted])
-    return result unless quality["publish_ready"] && Array(quality["warnings"]).empty?
+    # Same rule as the curator: an unattended publish needs the description verified,
+    # not merely complete.
+    return result unless quality["publish_ready"] && quality["description_verified"] && Array(quality["warnings"]).empty?
 
     proposal = CompanyProposal.find_by(id: result["proposal_id"])
     company = proposal&.company

--- a/app/services/company_proposal_apply_update_service.rb
+++ b/app/services/company_proposal_apply_update_service.rb
@@ -16,6 +16,12 @@ class CompanyProposalApplyUpdateService
     company = proposal.company
     changes = proposal.final_changes.slice(*CompanyProposal::EDITABLE_COMPANY_FIELDS)
     scalar_changes = changes.except("business_model_ids", "target_client_ids", "all_tags")
+
+    # This path writes straight onto a live company, and it runs autonomously when
+    # MCP_CURATOR_AUTOAPPLY_UPDATES is on. It was the remaining way a description could
+    # be replaced on a public record with no lock respected, no reason recorded and no
+    # history — so the same rules that govern a direct edit apply here.
+    scalar_changes = guard_description!(company, scalar_changes)
     company.assign_attributes(scalar_changes)
     company.visible = true if publish
     company.human_reviewed_at = Time.current
@@ -38,6 +44,31 @@ class CompanyProposalApplyUpdateService
   private
 
   attr_reader :proposal, :admin_user, :publish
+
+  # A locked description is not overwritten by an automated apply. A permitted change
+  # records what it replaced and why, the same as update_company_field.
+  def guard_description!(company, scalar_changes)
+    incoming = scalar_changes["description"].to_s.strip
+    return scalar_changes if incoming.blank? || incoming == company.description.to_s.strip
+
+    if description_locked?(company)
+      raise ArgumentError, "#{company.name}'s description is locked against automated changes. Unlock it, or edit it directly with a reason."
+    end
+
+    review = company.quality_review.is_a?(Hash) ? company.quality_review.deep_dup : {}
+    review["field_edits"] = Array(review["field_edits"]) + [{
+      "at" => Time.current.utc.iso8601,
+      "via" => "apply_user_suggestion",
+      "reason" => "Applied user suggestion #{proposal.id}#{" by #{admin_user.email}" if admin_user.respond_to?(:email)}",
+      "changes" => { "description" => { "from" => company.description, "to" => incoming } }
+    }]
+    company.quality_review = review
+    scalar_changes
+  end
+
+  def description_locked?(company)
+    company.quality_review.is_a?(Hash) && company.quality_review["description_locked"] == true
+  end
 
   def apply_associations!(company, changes)
     revenue_model_ids = Array(changes["business_model_ids"]).map(&:presence).compact

--- a/app/services/company_proposal_approval_service.rb
+++ b/app/services/company_proposal_approval_service.rb
@@ -3,11 +3,22 @@ class CompanyProposalApprovalService
     new(**kwargs).call
   end
 
-  def initialize(proposal:, admin_user:, duplicate_override: false, publish: false)
+  # reviewed_description_digest is the fingerprint of the description the reviewer was
+  # actually looking at when they approved. Guarding only the post-approval window was
+  # the wrong window: every description lost so far was overwritten while the record was
+  # still pending, seconds before the approval landed — 31s, 34s and 194s on the three
+  # records that prompted this. If the text has moved since it was rendered, the
+  # approval is refused rather than applied to something the reviewer never read.
+  def initialize(proposal:, admin_user:, duplicate_override: false, publish: false, reviewed_description_digest: nil)
     @proposal = proposal
     @admin_user = admin_user
     @duplicate_override = duplicate_override
     @publish = publish
+    @reviewed_description_digest = reviewed_description_digest.to_s.presence
+  end
+
+  def self.digest_for(description)
+    Digest::SHA256.hexdigest(description.to_s.strip)
   end
 
   def call
@@ -17,6 +28,7 @@ class CompanyProposalApprovalService
     # publish is requested; otherwise return the existing record unchanged.
     return promote_existing_company if proposal.company_id.present?
 
+    ensure_stale_review!
     ensure_description!
     validate_proposal!
 
@@ -59,7 +71,7 @@ class CompanyProposalApprovalService
 
   private
 
-  attr_reader :proposal, :admin_user, :duplicate_override, :publish
+  attr_reader :proposal, :admin_user, :duplicate_override, :publish, :reviewed_description_digest
 
   # Publish an already-created draft (or no-op if already visible). Publishing is
   # still the sensitive action, so it re-checks duplicate and publish blockers.
@@ -78,6 +90,18 @@ class CompanyProposalApprovalService
   # Duplicate state is resolved against the index and the open queue as they are now,
   # not as they were when the proposal was created. The message names the match so the
   # operator can act on it without going hunting.
+  # Refuse an approval whose subject changed underneath it.
+  def ensure_stale_review!
+    return if reviewed_description_digest.blank?
+
+    current = self.class.digest_for(proposal.final_changes["description"])
+    return if current == reviewed_description_digest
+
+    raise ArgumentError,
+          "The description changed after you opened this record — most likely an enrichment ran while you were reviewing. " \
+          "Reload the proposal and read the current text before approving."
+  end
+
   def validate_proposal!
     # Force a fresh resolution rather than reusing anything computed earlier in this
     # process: approval is the moment the answer has to be current, and a sibling

--- a/app/services/company_proposal_quality_service.rb
+++ b/app/services/company_proposal_quality_service.rb
@@ -28,6 +28,7 @@ class CompanyProposalQualityService
       "independent_evidence_count" => independent_evidence_count,
       "verification_state" => verification_state,
       "description_verification" => description_verification,
+      "description_verified" => description_verified?,
       "duplicate_signals" => proposal.current_duplicate_signals,
       "checked_at" => Time.current.utc.iso8601
     }
@@ -103,6 +104,14 @@ class CompanyProposalQualityService
   # not warnings: in both cases the reviewer has to look, so publication waits.
   def description_verification
     @description_verification ||= proposal.agent_details["description_verification"]
+  end
+
+  # True only when verification actually looked and approved. A skipped check is not a
+  # pass: the crash that used to block publishing was, by accident, the only thing
+  # keeping unreviewed machine text off the public index, so removing the block has to
+  # come with an explicit signal that autonomous publication can gate on.
+  def description_verified?
+    description_verification.present? && description_verification["decision"] == DescriptionVerificationService::APPROVE
   end
 
   def verification_blocker
@@ -196,6 +205,7 @@ class CompanyProposalQualityService
     values = []
     values << "Founding year is missing; publishing is allowed, but add a sourced year later when one is found (never fabricate)." if changes["founded_date"].blank?
     values << "No enrichment critic verdict is recorded." if proposal.agent_details.dig("description_critic", "verdict").blank?
+    values << verification_warning if verification_warning
     values << "Taxonomy was not auto-accepted." if taxonomy_suggestion.present? && !taxonomy_suggestion["accepted"]
     values
   end
@@ -268,6 +278,18 @@ class CompanyProposalQualityService
   # reason to trust the record.
   def verification_state
     independent_evidence_count.positive? ? "evidence_backed" : "unverified"
+  end
+
+  # Surfaced as a warning rather than a blocker: a reviewer looking at the record may
+  # publish it on their own judgement, but this is what stops anything autonomous doing
+  # so, and it tells them what was not checked.
+  def verification_warning
+    return nil if description_verified?
+    return nil if changes["description"].blank?
+    return nil if DescriptionVerificationService.blocking?(description_verification)
+
+    reason = description_verification.present? ? description_verification["accuracy_assessment"].presence : "verification has not run"
+    "This description has not been verified against the company's own pages#{" — #{reason}" if reason} It can be published by hand, but not automatically."
   end
 
   def usable_source_evidence_count

--- a/app/services/curator_pending_service.rb
+++ b/app/services/curator_pending_service.rb
@@ -88,14 +88,19 @@ class CuratorPendingService
     scope.to_a
   end
 
+  # Autonomous publication additionally requires that the description was actually
+  # verified against the company's own pages. publish_ready alone is a human's bar: it
+  # permits a reviewer to publish on their judgement, and nothing here has judgement.
   def can_autopublish?(quality, budget)
-    publish && Mcp::CuratorPolicy.autopublish_enabled? && quality["publish_ready"] && budget.positive?
+    publish && Mcp::CuratorPolicy.autopublish_enabled? && quality["publish_ready"] &&
+      quality["description_verified"] && budget.positive?
   end
 
   def skip_reason(quality, budget)
     return "publish_disabled_by_request" unless publish
     return "autopublish_kill_switch" unless Mcp::CuratorPolicy.autopublish_enabled?
     return "quality_gate" unless quality["publish_ready"]
+    return "description_not_verified" unless quality["description_verified"]
     return "daily_publish_budget_exhausted" unless budget.positive?
 
     "needs_review"

--- a/app/views/admin/company_proposals/show.html.slim
+++ b/app/views/admin/company_proposals/show.html.slim
@@ -46,6 +46,7 @@
                 = button_tag "Apply to Company", type: "submit", name: "publish", value: "0", class: "btn btn-success", data: { turbo_confirm: "Apply this suggestion to #{@company_proposal.company&.name}?" }
         - elsif !@company_proposal.duplicate_blocking?
             = form_with url: approve_custom_admin_company_proposal_path(@company_proposal), method: :post, local: true, class: "d-inline" do
+                = hidden_field_tag :reviewed_description_digest, CompanyProposalApprovalService.digest_for(@final_changes["description"])
                 = button_tag "Approve Draft", type: "submit", name: "publish", value: "0", class: "btn btn-outline-success", data: { turbo_confirm: "Approve this proposal as an invisible draft?" }, disabled: @company_proposal.company_id.present?
                 = button_tag "Publish", type: "submit", name: "publish", value: "1", class: "btn btn-success", data: { turbo_confirm: "Publish this proposal to the public site?" }, disabled: @company_proposal.company_id.present? || !@quality_report["publish_ready"]
 
@@ -58,6 +59,7 @@
                     .form-check.mb-0
                         = check_box_tag :duplicate_override, "1", false, class: "form-check-input", id: "duplicate_override"
                         = label_tag :duplicate_override, "I reviewed duplicates and still want to approve", class: "form-check-label small"
+                    = hidden_field_tag :reviewed_description_digest, CompanyProposalApprovalService.digest_for(@final_changes["description"])
                     .d-flex.gap-2
                         = button_tag "Approve Draft", type: "submit", name: "publish", value: "0", class: "btn btn-sm btn-outline-success", data: { turbo_confirm: "Approve this proposal as an invisible draft?" }, disabled: @company_proposal.company_id.present?
                         = button_tag "Publish", type: "submit", name: "publish", value: "1", class: "btn btn-sm btn-success", data: { turbo_confirm: "Publish this proposal to the public site?" }, disabled: @company_proposal.company_id.present? || !@quality_report["publish_ready"]

--- a/test/models/company_logo_fetch_test.rb
+++ b/test/models/company_logo_fetch_test.rb
@@ -90,7 +90,9 @@ class CompanyLogoFetchTest < ActiveSupport::TestCase
       final_changes: { "name" => company.name, "main_url" => company.main_url }
     )
     result = { "action" => "auto_drafted", "proposal_id" => proposal.id, "company_id" => company.id }
-    quality = { "publish_ready" => true, "warnings" => [] }
+    # Autonomous publication now also requires a verified description, so this stands in
+    # for the quality report of a record whose verification came back APPROVE.
+    quality = { "publish_ready" => true, "description_verified" => true, "warnings" => [] }
 
     with_logo_dev_key("pk_test") do
       with_stubbed_logo_network do

--- a/test/services/company_import_worker_service_test.rb
+++ b/test/services/company_import_worker_service_test.rb
@@ -104,4 +104,20 @@ class CompanyImportWorkerServiceTest < ActiveSupport::TestCase
       Test Company One,https://www.crunchbase.com/organization/test-company-one,"Legal Research, SaaS",2020-01-01,"San Francisco, California, United States","Duplicate of an existing company.",http://example.com,https://www.linkedin.com/company/test-company-one,Active,For Profit,1000000,1,1-10,Existing Founder,"Duplicate of an existing company."
     CSV
   end
+
+  # The rule that closed the autopublish exposure: an unattended publish needs the
+  # description verified, not merely complete.
+  test "a row whose description was not verified is held rather than published" do
+    run = nil
+    with_import_csv do |path|
+      run = CompanyImportSeedService.call(file: path, filename: "worker-test.csv", reviewer: "test@example.com", limit: 1)
+    end
+
+    assert_no_difference "Company.where(visible: true).count" do
+      with_site_evidence(verified: false) { CompanyImportWorkerService.drain(run_id: run.id, batch_limit: 1) }
+    end
+    row = run.company_import_rows.first.reload
+    assert_equal "held", row.status
+    refute_equal "published", row.action
+  end
 end

--- a/test/services/maintenance_tooling_test.rb
+++ b/test/services/maintenance_tooling_test.rb
@@ -124,4 +124,111 @@ class MaintenanceToolingTest < ActiveSupport::TestCase
     assert_equal @company.id, match["id"]
     assert_equal false, match["visible"], "and the caller can tell it is only a draft"
   end
+
+  # ---- 6. an unverified description may be published by hand, never by a machine ----
+
+  def gated_proposal(verification)
+    changes = {
+      "name" => "Zephyr Privacy", "main_url" => "https://zephyrprivacy.example",
+      "description" => "Zephyr Privacy builds anonymisation and redaction software for corporate legal teams and public authorities, deployed with EU hosting.",
+      "location" => "Wiesbaden, Germany", "founded_date" => "2019",
+      "category_id" => categories(:one).id,
+      "business_model_id" => business_models(:one).id, "business_model_ids" => [business_models(:one).id],
+      "target_client_id" => target_clients(:one).id, "target_client_ids" => [target_clients(:one).id]
+    }
+    CompanyProposal.create!(
+      status: "ready_for_review", proposal_type: "discovery_candidate", source: "llm_discovery",
+      source_identifier: SecureRandom.uuid, source_payload: {},
+      proposed_changes: changes, final_changes: changes, duplicate_signals: {},
+      enriched_at: Time.current,
+      agent_details: researched_agent_details(url: "https://zephyrprivacy.example").merge("description_verification" => verification)
+    )
+  end
+
+  test "a skipped verification leaves the record publishable by hand but not automatically" do
+    report = CompanyProposalQualityService.call(gated_proposal("decision" => "SKIPPED", "accuracy_assessment" => "The verifier could not run."))
+
+    assert report["publish_ready"], "a reviewer may still publish on their own judgement"
+    refute report["description_verified"], "but nothing autonomous may"
+    assert(report["warnings"].any? { |w| w.include?("has not been verified") })
+  end
+
+  test "an approved verification is the only thing that clears autonomous publication" do
+    approved = CompanyProposalQualityService.call(gated_proposal("decision" => "APPROVE"))
+    assert approved["description_verified"]
+    refute(approved["warnings"].any? { |w| w.include?("has not been verified") })
+
+    revised = CompanyProposalQualityService.call(gated_proposal("decision" => "REVISE"))
+    refute revised["description_verified"], "a revision is not a pass"
+  end
+
+  # ---- 7. approval refuses text the reviewer never read ------------------
+
+  test "an approval is refused when the description changed after it was rendered" do
+    record = gated_proposal("decision" => "APPROVE")
+    stale = CompanyProposalApprovalService.digest_for(record.final_changes["description"])
+    record.update!(final_changes: record.final_changes.merge("description" => "An enrichment replaced this text mid-review, dropping every named customer type."))
+
+    error = assert_raises(ArgumentError) do
+      CompanyProposalApprovalService.call(proposal: record, admin_user: @admin, publish: false, reviewed_description_digest: stale)
+    end
+    assert_match(/description changed after you opened this record/, error.message)
+    assert_nil record.reload.company_id, "nothing was created from text nobody read"
+  end
+
+  test "an approval proceeds when the text is unchanged" do
+    record = gated_proposal("decision" => "APPROVE")
+    digest = CompanyProposalApprovalService.digest_for(record.final_changes["description"])
+
+    company = CompanyProposalApprovalService.call(proposal: record, admin_user: @admin, publish: false, reviewed_description_digest: digest)
+    assert company.persisted?
+  end
+
+  # ---- 8. the auto-apply path obeys the same rules ----------------------
+
+  test "applying a user suggestion cannot overwrite a locked description" do
+    @company.update_columns(quality_review: { "description_locked" => true })
+    suggestion = CompanyProposal.create!(
+      status: "ready_for_review", proposal_type: "user_suggestion", source: "user_suggestion",
+      source_identifier: SecureRandom.uuid, source_payload: {}, company: @company,
+      proposed_changes: {}, final_changes: { "description" => "Replacement text from a suggestion that should not land." },
+      duplicate_signals: {}
+    )
+
+    error = assert_raises(ArgumentError) do
+      CompanyProposalApplyUpdateService.call(proposal: suggestion, admin_user: @admin)
+    end
+    assert_match(/locked against automated changes/, error.message)
+    refute_equal "Replacement text from a suggestion that should not land.", @company.reload.description
+  end
+
+  test "a permitted suggestion records what it replaced and why" do
+    replacement = "Veronto develops privacy and compliance software for corporate legal teams, public authorities and law firms."
+    suggestion = CompanyProposal.create!(
+      status: "ready_for_review", proposal_type: "user_suggestion", source: "user_suggestion",
+      source_identifier: SecureRandom.uuid, source_payload: {}, company: @company,
+      proposed_changes: {}, final_changes: { "description" => replacement }, duplicate_signals: {}
+    )
+    previous = @company.description
+
+    CompanyProposalApplyUpdateService.call(proposal: suggestion, admin_user: @admin)
+
+    edit = @company.reload.quality_review["field_edits"].last
+    assert_equal previous, edit["changes"]["description"]["from"]
+    assert_equal "apply_user_suggestion", edit["via"]
+  end
+
+  # ---- 9. taxonomy an enrichment got wrong is now reachable -------------
+
+  test "tags can be corrected and a wrong secondary category can be cleared" do
+    @company.update_columns(secondary_category_id: categories(:two).id)
+
+    call_tool(Mcp::Tools::UpdateCompanyFieldTool, slug: @company.slug,
+              fields: { "all_tags" => "artificial intelligence, cybersecurity, privacy", "secondary_category_id" => nil },
+              reason: "An enrichment dropped cybersecurity and set a secondary category that does not apply.")
+
+    @company.reload
+    assert_nil @company.secondary_category_id, "a wrong secondary category can be cleared"
+    assert_includes @company.tags.map(&:name), "cybersecurity"
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -62,8 +62,28 @@ class ActiveSupport::TestCase
   # pipeline around enrichment rather than the retrieval itself, so records come out
   # verified the way they do in production. The stand-in domain is deliberately inert so
   # it cannot collide with a fixture company and fake a duplicate match.
-  def with_site_evidence(url: "https://site-evidence.test", &block)
-    SiteEvidenceFetcherService.stub(:call, researched_agent_details(url: url)["site_evidence"], &block)
+  def with_site_evidence(url: "https://site-evidence.test", verified: true, &block)
+    SiteEvidenceFetcherService.stub(:call, researched_agent_details(url: url)["site_evidence"]) do
+      if verified
+        DescriptionVerificationService.stub(:call, approving_verification, &block)
+      else
+        block.call
+      end
+    end
+  end
+
+  # Autonomous publication requires a positive verification verdict, so a test standing
+  # in for a successful enrichment has to stand in for the verification too.
+  def approving_verification
+    {
+      "decision" => "APPROVE", "verified_company" => "Example Co", "verified_product" => "Example Platform",
+      "company_product_relationship" => "Example Co operates the Example Platform.",
+      "accuracy_assessment" => "Claims appear on the retrieved pages.",
+      "verified_claims" => ["legal software"], "issues_found" => [], "corrected_description" => nil,
+      "sources" => ["https://site-evidence.test"], "rejected_sources" => [], "confidence" => "HIGH",
+      "validation_notes" => [], "pages_retrieved" => ["https://site-evidence.test"],
+      "entity_resolved" => true, "mode" => "llm_verified", "generated_at" => Time.current.utc.iso8601
+    }
   end
 
   # Add more helper methods to be used by all tests here...


### PR DESCRIPTION
Three follow-ups on v539. **The first was a hole I opened.**

## 1. The crash was load-bearing

Making a crashed verifier non-blocking removed the only thing keeping unreviewed machine text off the public index. Skipped verification produced **no blocker and no warning** — and the import worker publishes on `publish_ready && warnings.empty?`, while `curate_pending` publishes on `publish_ready` alone. A fault on our side had been acting as the safety catch; removing it turned a stalled queue into an open door.

Verification is now a signal in its own right:

- `description_verified` is true **only** when verification looked and returned `APPROVE`
- both autonomous publish paths require it
- an unverified description raises a **warning, not a blocker** — a reviewer may publish on their own judgement; nothing autonomous may

A skipped check is not a pass. Neither is `REVISE`.

## 2. The enrichment guard watched the wrong window

My guard refused already-approved or already-reviewed records. But every description lost so far was destroyed while the record was still **pending** — **194s, 34s and 31s** before the approval landed.

The review page now stamps a digest of the description it rendered, and approval refuses if the text has moved since. An approval can no longer be applied to text the reviewer never read.

## 3. The lock only covered enrichment

`CompanyProposalApplyUpdateService` writes straight onto a live company and runs autonomously when `MCP_CURATOR_AUTOAPPLY_UPDATES` is on — which it is in production. It respected no lock and recorded no reason or previous value. It now refuses a locked description and records what it replaced.

## Also reachable now

`all_tags`, and `secondary_category_id` **including clearing it** — both cases an agent hit tonight where an enrichment had got the taxonomy wrong and nothing could put it right.

## Expected behaviour change

**CSV import will publish less on its own.** That is the intended effect — unattended publication of text nothing checked is the thing that caused this. Tests pin both directions: a verified row publishes, an unverified row is held.

## Testing

`bin/rails test` under CI's environment values: **674 runs, 3080 assertions, 0 failures**.

Three existing tests encoded the old autopublish rule and were updated to assert the new one, plus a new test that an unverified row is held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)