### PR TITLE
Stop filler words carrying a duplicate claim

### DIFF
--- a/app/services/proposal_duplicate_detector_service.rb
+++ b/app/services/proposal_duplicate_detector_service.rb
@@ -42,6 +42,8 @@ class ProposalDuplicateDetectorService
     legal law lex juris justice legaltech lawtech contract contracts case cases
     document documents docs compliance counsel court courts advocate advocates
     attorney attorneys firm firms client clients matter matters practice ip
+    that this these those which with from your their more best first next
+    company companies startup startups service tool tools system data
   ].freeze
   MIN_CORE_LENGTH = 4
 

--- a/test/services/proposal_duplicate_detector_service_test.rb
+++ b/test/services/proposal_duplicate_detector_service_test.rb
@@ -30,6 +30,17 @@ class ProposalDuplicateDetectorServiceTest < ActiveSupport::TestCase
     assert_equal "nextphone", ProposalDuplicateDetectorService.core_name("NextPhone Inc.")
   end
 
+  # Found by checking the live index: three scrape artifacts named "Platform that",
+  # "Platform that" and "Online platform that" were grouped as duplicates of each other
+  # on the core "that", which asserts nothing about identity.
+  test "core name refuses to assert identity on a filler word" do
+    assert_nil ProposalDuplicateDetectorService.core_name("Platform that")
+    assert_nil ProposalDuplicateDetectorService.core_name("Online platform that")
+    assert_nil ProposalDuplicateDetectorService.core_name("The company")
+    assert_equal "clausedelta", ProposalDuplicateDetectorService.core_name("ClauseDelta platform"),
+                 "a real name alongside a filler word still resolves"
+  end
+
   test "core name refuses to assert identity on a generic or tiny core" do
     assert_nil ProposalDuplicateDetectorService.core_name("Legal AI")
     assert_nil ProposalDuplicateDetectorService.core_name("Contracts Ltd")


### PR DESCRIPTION
Found by checking v541 against the live index, not by re-reading the code.

The core-name signal added **46** company pair groups. Sampling them, 7 of 8 were genuine (Lysias AI / Lysias, Midpage AI / Midpage, Advocat / Advocat Technologies, LawLens / Lawlens Tech…). One was noise:

```
core="that"   Platform that | Platform that | Online platform that
```

Those are the scrape artifacts from the original audit. `platform` was already treated as a suffix carrying no identity, which left a stopword as the entire core, and four characters was enough to clear the minimum.

Filler and category words now join the generic-core list, so a name reducing to one of them asserts nothing — while a real name beside a filler word still resolves (`ClauseDelta platform` → `clausedelta`).

**676 runs, 3093 assertions, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)